### PR TITLE
Add reusable release workflow for pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+on:
+  workflow_call:
+    # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callinputs
+    inputs:
+      pypi:
+        description: Publish to PyPI registry
+        default: false
+        type: boolean
+
+jobs:
+  pypi:
+    name: Publish to PyPI registry
+    if: "${{ inputs.pypi }}"
+    environment: release
+    runs-on: ubuntu-20.04
+
+    env:
+      FORCE_COLOR: 1
+      PY_COLORS: 1
+      TOXENV: packaging
+      TOX_PARALLEL_NO_SPINNER: 1
+
+    steps:
+
+    - name: Switch to using Python 3.8 by default
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install tox
+      run: >-
+        python3 -m pip install --user tox
+
+    - name: Check out src from Git
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # needed by setuptools-scm
+
+    - name: Build dists
+      run: python -m tox
+
+    - name: Publish to test.pypi.org
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.testpypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish to pypi.org
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This workflow should be easy to reuse from any project that needs to
publish to pypi.
