### PR TITLE
feat: add reusable ack workflow for labels

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -1,0 +1,25 @@
+# ack workflow runs on any change made to a pull-request and aims to verify
+# that is following our practices. Initial version is checking correct label
+# presence.
+name: ack
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+  workflow_call: # allows reuse of this workflow from other devtools repos
+
+jobs:
+  labels:
+    # Ensure that one of the required labels is present and none of the undesired is absent
+    # See https://github.com/jesusvasquez333/verify-pr-label-action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Verify PR label action
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          valid-labels: 'bug, enhancement, feature, refactoring, major, deprecated, skip-changelog'
+          invalid-labels: 'help wanted, invalid, feedback-needed, incomplete'
+          pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: true


### PR DESCRIPTION
This should allow us to make the old labels.yml workflow reusable
on all our repos and also make it more future-proof as we will
want to have other checks unrelated to labels, maybe some linting,
checking of PR title and body.