### PR TITLE
ack: enable release drafter auto-labeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,72 @@
+# Format and labels used by Ansible DevTools projects
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: 'Major Changes'
+    labels:
+      - 'major'  # c6476b
+  - title: 'Minor Changes'
+    labels:
+      - 'feature'  # 006b75
+      - 'enhancement'  # ededed
+      - 'refactoring'
+  - title: 'Bugfixes'
+    labels:
+      - 'bug'  # fbca04
+  - title: 'Deprecations'
+    labels:
+      - 'deprecated'  # fef2c0
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'refactoring'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+      - 'deprecated'
+  default: patch
+exclude-contributors:
+  - 'pre-commit-ci'
+autolabeler:
+  - label: 'skip-changelog'
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/chore/i'
+    body:
+      - '/type: chore/i'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+    body:
+      - '/type: fix/i'
+  - label: 'enhancement'
+    title:
+      - '/(enhance|improve)/i'
+    body:
+      - '/type: enhancement/i'
+  - label: 'feature'
+    title:
+      - '/feat/i'
+    body:
+      - '/type: feature/i'
+  - label: 'dreprecated'
+    title:
+      - '/deprecat(ed|ion)/i'
+    body:
+      - '/type: deprecat(ed|ion)/i'
+template: |
+  $CHANGES
+
+  Kudos goes to: $CONTRIBUTORS

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -9,12 +9,27 @@ on:
 
 jobs:
   labels:
-    # Ensure that one of the required labels is present and none of the undesired is absent
-    # See https://github.com/jesusvasquez333/verify-pr-label-action
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout
         uses: actions/checkout@v2
+
+      # Use of release drafter action for adding semantic labels based on
+      # either title, body or source branch name. We ignore potential failure
+      # of this step.
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # we only want to use the auto-labeler bits:
+          disable-autolabeler: false
+          disable-releaser: true
+        # config from .github/release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      # Ensure that one of the required labels is present and none of the undesired is absent
+      # See https://github.com/jesusvasquez333/verify-pr-label-action
       - name: Verify PR label action
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:


### PR DESCRIPTION
- copies release drafter config from ansible-lint project
- adds release-drafter labeler as optional step to ack workflow, just
  before the label verification.
- this should enable us to remove release-drafter config from our repositories and have a single shared configuration