### PR TITLE
add reusable push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,22 @@
+# push workflow is shared and expected to perform actions after a merge happens
+# on a maintenance branch (default or release). For example updating the
+# draft release-notes.
+name: push
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+      - 'releases/**'
+      - 'stable/**'
+  workflow_call: # allows reuse of this workflow from other devtools repos
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds an reusable workflow names push which is supposed to run after
a merge happens on a maintenance branch.

Basically that is the same configuration used inside ansible-lint and molecule-* projects.