### PR TITLE
Remove kudos section from drafted changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -73,5 +73,3 @@ autolabeler:
       - '/type: deprecat(ed|ion)/i'
 template: |
   $CHANGES
-
-  Kudos goes to: $CONTRIBUTORS


### PR DESCRIPTION
As Github already started to automatically add a Contributors section to releases, we no longer need to mention them at the and of the drafted changelog.

Example:
![](https://sbarnea.com/ss/Screen-Shot-2021-10-26-11-18-32.53.png)