### PR TITLE
Add required input secrets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,15 @@ on:
       pypi:
         description: Publish to PyPI registry
         default: false
+        required: false
         type: boolean
+    secrets:
+      pypi_password:
+        description: 'API token for pypi.org'
+        required: true
+      testpypi_password:
+        description: 'API token for test.pypi.org'
+        required: true
 
 jobs:
   pypi:


### PR DESCRIPTION
Release workflow should have required secrets input to be re-usable from other repositories