### PR TITLE
Test beta RPMs

### DIFF
--- a/test/ubi8/Dockerfile
+++ b/test/ubi8/Dockerfile
@@ -1,0 +1,35 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest as adt
+
+COPY <<EOF /etc/yum.repos.d/aap.repo
+[aap25]
+name=aap25
+baseurl='https://rhsm-pulp.corp.stage.redhat.com/content/beta/layered/rhel$releasever/$basearch/ansible-developer/1-beta/os/'
+gpgcheck=0
+enabled=1
+module_hotfixes=1
+EOF
+
+RUN <<EOF
+    dnf remove -y subscription-manager dnf-plugin-subscription-manager
+    dnf install -y ansible-dev-tools
+    dnf clean all
+EOF
+RUN <<EOF
+    set -e
+    echo "Show adt version."
+    adt --version
+    echo "Show ansible-creator version."
+    ansible-creator --version
+    echo "Show ansible-lint version."
+    ansible-lint --version
+    echo "Show ansible-navigator version."
+    ansible-navigator --version
+    echo "Show molecule version."
+    molecule --version
+    echo "Show ade version."
+    ade --version
+    echo "Check if tox recognizes tox-ansible plugin."
+    tox --version | grep tox-ansible
+    echo "Check if pytest recognizes pytest-ansible plugin."
+    pytest-3.11 --version -VV | grep pytest-ansible
+EOF

--- a/test/ubi9/Dockerfile
+++ b/test/ubi9/Dockerfile
@@ -1,0 +1,35 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest as adt
+
+COPY <<EOF /etc/yum.repos.d/aap.repo
+[aap25]
+name=aap25
+baseurl='https://rhsm-pulp.corp.stage.redhat.com/content/beta/layered/rhel$releasever/$basearch/ansible-developer/1-beta/os/'
+gpgcheck=0
+enabled=1
+module_hotfixes=1
+EOF
+
+RUN <<EOF
+    dnf remove -y subscription-manager dnf-plugin-subscription-manager
+    dnf install -y ansible-dev-tools
+    dnf clean all
+EOF
+RUN <<EOF
+    set -e
+    echo "Show adt version."
+    adt --version
+    echo "Show ansible-creator version."
+    ansible-creator --version
+    echo "Show ansible-lint version."
+    ansible-lint --version
+    echo "Show ansible-navigator version."
+    ansible-navigator --version
+    echo "Show molecule version."
+    molecule --version
+    echo "Show ade version."
+    ade --version
+    echo "Check if tox recognizes tox-ansible plugin."
+    tox --version | grep tox-ansible
+    echo "Check if pytest recognizes pytest-ansible plugin."
+    pytest-3.11 --version -VV | grep pytest-ansible
+EOF

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ minversion = 4.0
 envlist =
     lint
     docs
+    ubi8
+    ubi9
 isolated_build = True
 requires =
     tox>=4.0.12
@@ -35,3 +37,12 @@ deps = pre-commit>=1.18.1
 extras =
 skip_install = true
 usedevelop = false
+
+[testenv:{ubi8,ubi9}]
+description = Building container using beta RPMs (requires VPN) {envname}
+changedir = test/{envname}
+commands =
+    podman build --tag adt-{envname} {posargs} .
+    podman run -it adt-{envname} adt --version
+allowlist_externals =
+    podman


### PR DESCRIPTION
These do not run on GHA, run manually `tox -e ubi8` and `tox -e ubi9` when inside VPN to test.

Found problems:

- [x] pytest-ansible missing
- [x] pytest missing
- [x] `ansible-dev-tools` bin missing. only `adt` present
- [x] `ansible-dev-environment` bin missing, only `ade` present
- [x] `ansible-lint --version` reports newer linter version being available from pip, when it should not do this for rpm installs.
- [x] `adt server` reports missing components (expected for first beta)

https://issues.redhat.com/browse/AAP-24936 -> https://issues.redhat.com/browse/AAP-23001