### PR TITLE
Pin codecov action to v4.5.0 and update dependabot.yml to ignore v4.6.0

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 ---
 exclude_paths:
   - mkdocs.yml
+  - dependabot.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
       interval: daily
     labels:
       - skip-changelog
+    ignore:
+      - dependency-name: "codecov/codecov-action"
+        versions: ["4.6.0"]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -176,7 +176,7 @@ jobs:
           fi
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: ${{ matrix.name }}
           fail_ci_if_error: true


### PR DESCRIPTION
Changes the codecov version in our tox workflow from v4 to v4.5.0, since v4.6.0 introduced a regression causing this error:

Error: `Codecov: Failed to get OIDC token with url: https://codecov.io./ Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`

Updates `dependabot.yml` to skip version v4.6.0. 
Adds `dependabot.yml` to the `.ansible-lint` exclude_paths list, since it's failing on the quotes surrounding the `dependency_name` and `versions` values. 

Codecov issue: https://github.com/codecov/codecov-action/issues/1594