### PR TITLE
Revert "Bump codecov/codecov-action from 4.5.0 to 5.0.2"

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Upload coverage data
         if: ${{ inputs.jobs_producing_coverage }}
-        uses: codecov/codecov-action@v5.0.2
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: ${{ matrix.name }}
           fail_ci_if_error: true


### PR DESCRIPTION
Reverts ansible/team-devtools#244 due to https://github.com/codecov/codecov-action/issues/1659