### PR TITLE
Add maintenance section to release drafter notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,10 +18,10 @@ categories:
   - title: Bugfixes
     labels:
       - bug # fbca04
-  - title: Other # fef2c0
-exclude-labels:
-  - bot:chronographer:skip
-  - skip-changelog
+  - title: Maintenance # fef2c0
+    labels:
+      - chore
+      - skip-changelog
 replacers:
   # https://github.com/release-drafter/release-drafter/issues/569#issuecomment-645942909
   - search: /(?:and )?@(pre-commit-ci|dependabot)(?:\[bot\])?,?/g
@@ -47,7 +47,7 @@ exclude-contributors:
   - dependabot
   - pre-commit-ci
 autolabeler:
-  - label: skip-changelog
+  - label: chore
     title:
       - /pre-commit autoupdate/
     body:

--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -50,6 +50,7 @@ jobs:
           exit_type: failure
           labels: |
             bug
+            chore
             enhancement
             major
             minor


### PR DESCRIPTION
From now on, skip-changelog and chore labeled merged changes will be mentioned on a section called 'Maintenance' when building release notes. This should highlight the amount of invisible work done for maintaining the codebase.

'Maintenance' seems to be the most common name for this section based on a search on github.
