### PR TITLE
Replace action/upload-artifact with a more secure alternative

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -201,13 +201,16 @@ jobs:
         run: ${{ inputs.run_post }}
 
       - name: Archive logs and coverage data
-        uses: actions/upload-artifact@v4
+        uses: coactions/upload-artifact@v4
         with:
           name: logs-${{ matrix.name }}.zip
           include-hidden-files: true
+          if-no-files-found: error
           path: |
-            .tox/**/log/
+            .tox/**/pyvenv.cfg
             .tox/**/coverage.xml
+          # Temporary disable of tox log collection until its new release:
+          # .tox/**/log/
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && hashFiles('junit.xml') != '' }}

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,6 @@ uv_seed = true
 [testenv:docs]
 description = Build docs
 extras = docs
-passenv =
-    *
 setenv =
   # see https://github.com/tox-dev/tox/issues/2092#issuecomment-2538729079
   # see https://github.com/Kozea/CairoSVG/issues/392#issuecomment-2538707712


### PR DESCRIPTION
Related: AAP-46204
Related: https://github.com/tox-dev/tox/pull/3543