### PR TITLE
Improve documentation for devtools releases

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,3 +1,4 @@
+SME
 abhikdps
 alisonlhart
 cidrblock

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+docs/_abbreviations.md
 docs/stats/repos.md
 # done by ansible-lint
 *.yml

--- a/docs/_abbreviations.md
+++ b/docs/_abbreviations.md
@@ -1,0 +1,6 @@
+*[deliverable]: A package, container or application that is supposed to be published at the end of the build.
+*[GHA]: GitHub Actions CI/CD
+*[PR]: Pull Request
+*[ADT]: Ansible Dev Tools, also known as ansible-dev-tools python package.
+*[PDE]: Product Delivery Engineering
+*[SME]: Subject Matter Expert, check team google doc for current assignations.

--- a/docs/guides/releases.md
+++ b/docs/guides/releases.md
@@ -4,13 +4,23 @@
 
 The projects maintained by the Ansible dev tools team have a target release frequency of 1 month. Some project may have more than 1 release per month based on project velocity or frequency of bug fixes or feature additions.
 
-One person within the devtools team will act as "release manager" each month. This will ensure each project is reviewed to ensure a release for that month was made. If a particular project's CI tests are failing, the project maintainer will work with the release manager to clear the block. If a project already has a release within the current month a new release is not necessary unless there are merged PRs and release notes available for a new release.
+One person within the devtools team will act as **release manager** each month. This will ensure each project is reviewed to ensure a release for that month was made.
 
-The following project should be released first, in no particular order:
+## Checklist
+
+- [ ] If a particular project's CI tests are failing, the release manager will coordinate with the project' SME to clear the block using [#ansible-devtools] slack channel.
+- [ ] If a project already has a release within the current month a new release is not necessary unless there are merged PRs and release notes available for a new release.
+- [ ] A release should be made only if it contains at least one change that is changing the deliverable.
+
+## Release order
+
+### Python projects
+
+Stage 1, release below if needed:
 
 - [ansible-compat](https://github.com/ansible/ansible-compat/releases)
 
-The following projects should be released second, in no particular order:
+Stage 2, release the following projects, in no particular order:
 
 - [ansible-creator](https://github.com/ansible/ansible-creator/releases)
 - [ansible-dev-environment](https://github.com/ansible/ansible-dev-environment/releases)
@@ -19,15 +29,16 @@ The following projects should be released second, in no particular order:
 - [molecule](https://github.com/ansible/molecule/releases)
 - [pytest-ansible](https://github.com/ansible/pytest-ansible/releases)
 - [tox-ansible](https://github.com/ansible/tox-ansible/releases)
-- [VsCode extension](https://github.com/ansible/vscode-ansible/releases)
 
-Before a downstream release, also release the following:
+### Update galaxy-importer before downstream release
 
 - [galaxy-importer](https://github.com/ansible/galaxy-importer)
-  - Update ansible-lint version in [setup.cfg](https://github.com/ansible/galaxy-importer/blob/master/setup.cfg) and open a PR. Ensure the ansible-lint version is confirmed for the downstream release before doing this. Ask the Hub team to review the PR in either `#ansible-galaxy-internal` or `#wg-hub-delivery` Slack channels.
-  - Notify Partner Engineering about the ansible-lint version update in importer in the `#ansible-partners` Slack channel using `@ansible-pe`.
+  - Update ansible-lint version in [setup.cfg](https://github.com/ansible/galaxy-importer/blob/master/setup.cfg) and open a PR. Ensure the ansible-lint version is confirmed for the downstream release before doing this. Ask the Hub team to review the PR in either [#ansible-galaxy-internal] or [#wg-hub-delivery] Slack channels.
+  - Notify Partner Engineering about the ansible-lint version update in importer in the [#ansible-partners] Slack channel using `@ansible-pe`.
   - Ask the Hub team to make a new release of galaxy-importer.
   - Add the new released version of importer to downstream packages list to notify PDE of the change.
+
+### ADT Release
 
 Finally, after running dependabot so the release notes are updated with dependencies:
 
@@ -38,7 +49,11 @@ This will release both a python project and image. Both the resulting python pac
 - [ansible-dev-tools on pypi](https://pypi.org/project/ansible-dev-tools/#history)
 - [ansible-dev-tools image](https://github.com/ansible/ansible-dev-tools/pkgs/container/community-ansible-dev-tools)
 
-## Step after ADT release - Update devspaces sandbox image
+### vscode-ansible
+
+Our [vscode-ansible](https://github.com/ansible/vscode-ansible/releases) extension needs to be released after ADT package is released because it uses both the python packages and the container image. Trying to release it with only the python packages being updated will result in testing with older versions when using the execution environment.
+
+### Update DevSpaces image
 
 Whenever the upstream `ansible-devspaces` container is released, the image SHA in the `devfile.yaml` of [ansible-devspaces-demo](https://github.com/redhat-developer-demos/ansible-devspaces-demo) repository must be updated. Verification needed whether the automated pull request for this update has been created correctly.
 
@@ -163,4 +178,7 @@ Release manager: @alisonlhart
 
 Completed date: 2024-07-18
 
-Notes:
+[#ansible-partners]: https://redhat.enterprise.slack.com/archives/CE3UL7F8V
+[#ansible-galaxy-internal]: https://redhat.enterprise.slack.com/archives/CBPKRHHG9
+[#wg-hub-delivery]: https://redhat.enterprise.slack.com/archives/C07BMJL2X42
+[#ansible-devtools]: https://redhat.enterprise.slack.com/archives/C01NQV614EA

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,14 +3,17 @@ site_name: Ansible DevTools
 site_url: https://ansible.readthedocs.io/projects/team-devtools/
 repo_url: https://github.com/ansible/team-devtools
 edit_uri: blob/main/docs/
-copyright: Copyright © 2023 Red Hat, Inc.
+copyright: Copyright © Red Hat, Inc.
 
 theme:
   name: ansible
   features:
     - content.code.copy
     - content.action.edit
+    - content.tooltips
     - navigation.expand
+exclude_docs: |
+  _abbreviations.md
 extra:
   social:
     - icon: fontawesome/brands/github-alt
@@ -54,6 +57,8 @@ plugins:
   #       - index.md
 
 markdown_extensions:
+  - abbr
+  - attr_list
   - admonition
   - def_list
   - footnotes
@@ -61,6 +66,8 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets:
+      auto_append:
+        - docs/_abbreviations.md
       check_paths: true
   - pymdownx.superfences
   - pymdownx.magiclink:
@@ -73,9 +80,11 @@ markdown_extensions:
       normalize_issue_symbols: true
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - toc:
       # reduced to keep TOC nice under Changelog page
-      toc_depth: 2
+      toc_depth: 3
       permalink: true
   - pymdownx.superfences:
       custom_fences:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ requires-python = ">=3.10"
 [tool.coverage.paths]
 source = ["src", "test", ".tox/*/site-packages"]
 
+
+[tool.codespell]
+ignore-words-list = ["SME"]
+
 [tool.coverage.report]
 exclude_also = ["pragma: no cover", "if TYPE_CHECKING:"]
 # Increase it just so it would pass on any single-python run


### PR DESCRIPTION
- Mentions that we should make a release only when the deliverable
  is modified.
- Adds abbreviations
- Improved readability

AAP-46585