### PR TITLE
fix: forum_post.py post date

### DIFF
--- a/.github/workflows/forum_post.py
+++ b/.github/workflows/forum_post.py
@@ -88,7 +88,7 @@ class Post:
         with urllib.request.urlopen(release_url) as url:  # noqa: S310
             data = json.load(url)
         self.release_notes = data["body"]
-        self.created = data["created_at"]
+        self.created = data["published_at"]
 
     def _get_category_id(self) -> None:
         """Get the category ID for the project."""


### PR DESCRIPTION
Under the assumption that we want the post to have the same timestamp as the release for some reason, use "published_at" instead of "created_at", as published is the timestamp of the release, while created is the timestamp of the most recent commit to the tag