### PR TITLE
Add project tag to forum posts

### DIFF
--- a/.github/workflows/forum_post.py
+++ b/.github/workflows/forum_post.py
@@ -117,7 +117,7 @@ class Post:
             "raw": post_md,
             "category": self.category_id,
             "created_at": self.created,
-            "tags": ["devtools", "release-management"],
+            "tags": ["devtools", "release-management", self.project_short],
         }
 
     def post(self) -> None:

--- a/.github/workflows/forum_post.py
+++ b/.github/workflows/forum_post.py
@@ -117,7 +117,7 @@ class Post:
             "raw": post_md,
             "category": self.category_id,
             "created_at": self.created,
-            "tags": ["devtools", "release-management", self.project_short],
+            "tags": ["devtools", "release", self.project_short],
         }
 
     def post(self) -> None:

--- a/test/test_forum_post.py
+++ b/test/test_forum_post.py
@@ -45,5 +45,5 @@ def test_prepare_post(post_instance: forum_post.Post) -> None:
         "raw": release_notes,
         "category": post_instance.category_id,
         "created_at": post_instance.created,
-        "tags": ["devtools", "release-management"],
+        "tags": ["devtools", "release-management", "molecule"],
     }

--- a/test/test_forum_post.py
+++ b/test/test_forum_post.py
@@ -45,5 +45,5 @@ def test_prepare_post(post_instance: forum_post.Post) -> None:
         "raw": release_notes,
         "category": post_instance.category_id,
         "created_at": post_instance.created,
-        "tags": ["devtools", "release-management", "molecule"],
+        "tags": ["devtools", "release", "molecule"],
     }


### PR DESCRIPTION
Adds an additional tag from the value of `project_short` (`project` with the user/org stripped off) for specificity.