### PR TITLE
fix: use only one flag when uploading to codecov

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -220,7 +220,9 @@ jobs:
           disable_search: true
           plugins: noop
           files: "**/coverage.xml"
-          flags: ${{ matrix.python_version }},${{ runner.os }},${{ runner.arch }}
+          # Only one flag is allowed since https://github.com/codecov/gazebo/pull/3375
+          # os is not needed because is detected automatically
+          flags: ${{ runner.arch }}-${{ matrix.python_version }}
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
       - name: Upload test results to codecov.io


### PR DESCRIPTION
Related: https://github.com/codecov/gazebo/pull/3375
Related: https://github.com/codecov/codecov-action/issues/1522
