### PR TITLE
chore: disable codenotify action

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -283,9 +283,10 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
-      - name: Notify repository owners about changes affecting them
-        uses: sourcegraph/codenotify@54e4320f0d93f162a371d8d9dc1fb11018199746 # v0.6.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # https://github.com/sourcegraph/codenotify/issues/19
-        continue-on-error: true
+      # See: https://github.com/sourcegraph/codenotify/issues/32
+      # - name: Notify repository owners about changes affecting them
+      #   uses: sourcegraph/codenotify@54e4320f0d93f162a371d8d9dc1fb11018199746 # v0.6.4
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   # https://github.com/sourcegraph/codenotify/issues/19
+      #   continue-on-error: true


### PR DESCRIPTION
As this proved to cause some execution failures, we currently disable it.

Related: https://github.com/sourcegraph/codenotify/issues/32