### PR TITLE
fix(ci): stabilize ack and lint for Renovate PRs

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -92,6 +92,8 @@ jobs:
           github.event.pull_request.user.login == 'pre-commit-ci[bot]' ||
           github.event.pull_request.user.login == 'renovate[bot]'
           )
+        continue-on-error: true
+        # Expired or mis-scoped BOT_PAT would otherwise fail the whole ack job (401 from gh).
         run: |
           set -e
           gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Commit & push changes
         id: commit-and-push
         if: steps.prek.outcome == 'failure'
+        continue-on-error: true
         # git config push.default upstream
         run: |
           git config user.email "devtools@ansible.com"
@@ -66,14 +67,27 @@ jobs:
           git commit -m "chore[bot]: auto-fix lint errors"
           git push
 
+      - name: Fail if lint fixes could not be published
+        if: >
+          github.event_name == 'pull_request' &&
+          steps.prek.outcome == 'failure' &&
+          steps.commit-and-push.outcome != 'success'
+        run: |
+          echo "::error::Pre-commit reported issues and the auto-fix could not be pushed." \
+            "Common causes: repository rules require signed commits (configure GPG signing for the bot PAT)," \
+            "or the push token lacks permission. Check the 'Commit & push changes' step log."
+          exit 1
+
       - name: react if linting errors were not fixed
-        if: steps.commit-and-push.outcome  == 'failure'
+        if: >
+          github.event_name == 'pull_request' &&
+          steps.commit-and-push.outcome == 'failure'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: |
             @${{ github.actor }} I tried to fix the linting errors, but it didn't work. Please fix them manually.
-            See [CI log](https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+            See [CI log](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
 
   test:
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,8 @@ repos:
       - id: codespell
         priority: 0
         additional_dependencies: ["tomli>=2.2.1; python_version<'3.11'"]
-  - repo: builtin
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
         priority: 0


### PR DESCRIPTION
## Summary
- **ack**: `continue-on-error` on the bot approve/auto-merge step so a bad or expired `BOT_PAT` (401) no longer fails the entire ack job.
- **test (lint)**: `continue-on-error` on commit-and-push; explicit failure with a clear message when pre-commit fixes cannot be published (e.g. rules requiring signed commits); fix PR comment to use `github.event.pull_request.number` (issue.number is empty on pull_request events).
- **pre-commit**: replace deprecated `repo: builtin` with `pre-commit-hooks` v5.0.0 so current pre-commit parses the config (required `rev`).

## Note
Renovate PRs in this repo may still need a **signed** follow-up commit for lockfile/hook drift until GPG signing is configured for the bot or rules are adjusted. This PR addresses CI mis-signalling and ack blocking from PAT issues.

Related: open Renovate PRs (#444, #446) and the same ack pattern in other ansible devtools repos.