### PR TITLE
feat: add agent skills for PR workflows and cross-repo sync

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,57 @@
+# Agent Skills
+
+Agent skills for development workflow automation in team-devtools.
+
+## Available Skills
+
+### Pull Requests (`pr-*`)
+
+| Skill | Purpose | Arguments |
+|-------|---------|-----------|
+| `pr-new` | Prepare and submit a pull request | `[branch-name] [--title 'PR title']` |
+| `pr-review` | Handle PR review feedback | `<PR number>` |
+| `pr-contributor-review` | Review and prepare a contributor's PR (upstream/fork) | `<PR number or URL>` |
+
+### Utilities
+
+| Skill | Purpose | Arguments |
+|-------|---------|-----------|
+| `tox` | tox environment reference (lint, test, docs, pkg) | `[environment-name]` |
+
+## Skill Structure
+
+```
+skills/
+├── README.md                   ← You are here
+├── pr-new/
+│   └── SKILL.md
+├── pr-review/
+│   └── SKILL.md
+├── pr-contributor-review/
+│   └── SKILL.md
+└── tox/
+    └── SKILL.md
+```
+
+## SKILL.md Format
+
+Each skill has YAML frontmatter:
+
+```yaml
+---
+name: skill-name
+description: >-
+  What the skill does. When to use it. Trigger phrases.
+argument-hint: "[expected arguments]"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+```
+
+## Version
+
+- **Version**: 1.0.0
+- **Author**: Ansible DevTools Team
+- **License**: GPL-3.0-or-later

--- a/.agents/skills/pr-contributor-review/SKILL.md
+++ b/.agents/skills/pr-contributor-review/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: pr-contributor-review
+description: >
+  Use when reviewing and preparing a contributor's pull request (upstream or
+  fork). Use when the user asks to review a PR, get a contributor PR ready,
+  update a contributor's branch, or ensure a PR meets project standards before
+  merge.
+argument-hint: "<PR number or URL>"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# Review Contributor PR
+
+This skill defines how to review and assist with a **contributor's** pull
+request (someone else's PR, e.g. from a fork or another branch). Use it when
+you are helping make a contributor PR merge-ready, not when submitting your
+own PR (use `pr-new` for that).
+
+## Goals
+
+- PR is **up to date with upstream main** (no merge conflicts, clean rebase).
+- **Quality gates pass**: `tox -e lint` and `tox -e py` on the full tree.
+- **PR description** follows the project template (Summary, Changes, Test plan)
+  so reviewers and history have clear context.
+- Avoid pushing to the contributor's branch with failing CI or an outdated base.
+
+## Workflow
+
+### 1. Fetch PR metadata and diff
+
+Use the GitHub API or `gh pr view` to get:
+
+- PR number, title, body, base/head refs, author.
+- List of changed files and patch/diff.
+
+Confirm the **base** branch (e.g. `ansible:main`) and that you know which
+remote/branch you will push to if you make changes.
+
+### 2. Check if the branch is up to date with upstream
+
+- Fetch `upstream main` (or the base branch).
+- Compare base ref of the PR to current `upstream/main`. If upstream has
+  newer commits, the contributor's branch should be rebased (or merged) onto
+  `upstream/main` before merge.
+
+If you are going to push changes to the contributor's branch (e.g. adding
+fixes or improving the PR):
+
+- Rebase the **local** branch that mirrors their PR onto `upstream/main`
+  before pushing. That way the PR stays mergeable and CI runs against the
+  latest main.
+
+### 3. Run quality gates before pushing
+
+Run tox quality gates on the **entire** tree, not only the changed files:
+
+```bash
+tox -e lint
+tox -e py
+```
+
+Fix any failures (line length, untyped decorators, docstring sections, format,
+test regressions) before pushing to the contributor's branch.
+
+Do **not** run `ruff`, `mypy`, `pytest`, or `prek` directly — always use tox.
+See the `/tox` skill for the full environment reference.
+
+Do **not** push to the contributor's branch if tox fails; fix in a new commit
+and then push so CI stays green.
+
+### 4. PR description quality
+
+- If the PR body is minimal or missing structure, suggest or apply the
+  **pr-new** template: Summary, Changes, Test plan.
+
+- You can update the PR body via GitHub (if you have permission) or draft
+  text for the maintainer/contributor to paste:
+
+  ```bash
+  gh pr edit <N> --repo ansible/team-devtools --body-file path/to/body.md
+  ```
+
+- Keep the description accurate: list what changed and how to verify (tests,
+  manual steps).
+
+### 5. Pushing to the contributor's branch
+
+- Only push to the contributor's fork/branch if you have permission and the
+  user has asked you to.
+
+- Before pushing:
+
+  1. Rebase onto `upstream/main` so the PR is up to date.
+  2. Ensure `tox -e lint` and `tox -e py` pass (see step 3).
+  3. Use `--force-with-lease` when pushing a rebased branch:
+     `git push <remote> <local-branch>:<their-branch> --force-with-lease`.
+
+- After pushing, the PR will update automatically. Optionally update the PR
+  description to mention the new commits.
+
+### 5a. Comment on review threads
+
+When you push fixes that address a review comment, reply on that thread so
+the resolution is visible. Follow the **`pr-review`** skill for the full
+procedure (REST reply endpoint, finding comment IDs, GraphQL thread resolution).
+
+### 5b. Track all deferred work as issues
+
+When reviewing a contributor PR, any suggestion that work should happen in a
+follow-up PR — whether from you, the contributor, or another reviewer — **MUST**
+be captured as a GitHub issue immediately. Do not leave "TODO for later" or
+"out of scope, will address separately" without creating an issue. Untracked
+follow-ups are invisible debt.
+
+```bash
+gh issue create --repo ansible/team-devtools \
+  --title "<type>(scope): <description from review>" \
+  --body "$(cat <<'EOF'
+## Context
+
+<What was deferred and why>
+
+Flagged during review of PR #N: <link to comment>
+
+## Proposal
+
+<What should be done>
+
+EOF
+)"
+```
+
+Include the issue URL in the PR comment thread so reviewers can verify tracking.
+
+### 6. What not to include in the review
+
+- **Local-only or environment-specific issues** (e.g. commit signing, SSH
+  config, IDE settings) should not be part of the contributor-PR review
+  checklist unless they are project policy. Document those separately or in
+  maintainer docs if needed.
+
+## Checklist (quick reference)
+
+When reviewing or preparing a contributor PR:
+
+- [ ] Fetched PR and know base/head and remotes.
+- [ ] Branch is up to date with upstream main (rebase if needed before push).
+- [ ] `tox -e lint` and `tox -e py` pass.
+- [ ] PR description has Summary, Changes, and Test plan (pr-new style).
+- [ ] If pushing to their branch: rebase onto upstream main, tox green, then
+      `git push <remote> <local>:<their-branch> --force-with-lease`.
+- [ ] If you addressed a review comment: follow the `pr-review` skill to reply
+      on the thread with explanation + commit SHA and resolve it.
+
+## References
+
+- **tox skill** (`/tox`): Full tox environment reference.
+- **pr-new** skill: PR body template and commit conventions.
+- **pr-review** skill: Responding to review comments and resolving threads.
+- **AGENTS.md**: Commit message standards and static check requirements.

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: pr-new
+description: >
+  Prepare and submit a pull request. Syncs with upstream,
+  creates a feature branch, runs quality gates (tox -e lint, tox -e py),
+  updates documentation as needed, commits with conventional commits,
+  then creates the PR via gh. Use when the user asks to submit, create, or open
+  a pull request, or says "submit PR", "open PR", "create PR", "new PR".
+argument-hint: "[branch-name] [--title 'PR title']"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# PR New
+
+## Workflow
+
+### Step 1: Sync with upstream and create a feature branch
+
+Always start from the latest upstream main:
+
+```bash
+git fetch upstream
+git checkout -b <branch-name> upstream/main
+```
+
+Use a descriptive branch name (e.g., `feat/add-jira-labels`, `fix/check-constraints`).
+
+If changes already exist on the current branch (e.g., from an in-progress session), cherry-pick or rebase them onto the new branch.
+
+### Step 2: Run quality gates
+
+```bash
+tox -e lint
+tox -e py
+```
+
+**Both must pass cleanly on the full tree** — not just the files you changed.
+If the branch has pre-existing violations (e.g., from an old base), rebase onto `upstream/main` first.
+
+Do **not** run `ruff`, `mypy`, `prek`, or `pytest` directly — always use tox.
+See the `/tox` skill for the full environment reference.
+
+### Step 3: Update documentation
+
+Check whether your changes affect areas covered by existing docs. Update any that apply:
+
+| Doc | When to update |
+|-----|----------------|
+| `README.md` | Project overview, dependency diagrams, setup changes |
+| `docs/guides/` | New dev workflows, guide additions |
+| `docs/stats/` | Statistics or metrics changes |
+
+### Step 4: Commit with conventional commits
+
+Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types for this project:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature (CLI command, workflow, utility) |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Code style/formatting (no logic change) |
+| `refactor` | Code restructuring (no feature or fix) |
+| `test` | Adding or updating tests |
+| `build` | Build system, dependencies |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance tasks |
+
+Scopes reflect project areas: `jira`, `check`, `docs`, `ci`, `deps`, `config`.
+
+Examples:
+- `feat(jira): add bulk issue creation support`
+- `fix(check): handle missing platform constraints gracefully`
+- `docs: update release process guide`
+- `ci: add Python 3.14 to test matrix`
+
+Include ticket references in the commit footer:
+- `Fixes: #123` for GitHub issues
+- `Related: AAP-123` for JIRA tickets
+- Do not use URLs — use plain text references
+
+### Step 5: Push and create the pull request
+
+```bash
+git push -u origin HEAD
+
+gh pr create --repo ansible/team-devtools --title "conventional commit style title" --body "$(cat <<'EOF'
+## Summary
+- Concise description of what changed and why
+
+## Changes
+- List of notable changes
+
+## Test plan
+- [ ] `tox -e lint` passes
+- [ ] `tox -e py` passes
+- [ ] Docs updated (if applicable)
+EOF
+)"
+```
+
+The PR targets upstream's `main` branch from the fork. Return the PR URL to the user.
+
+### Maintaining the PR
+
+When pushing additional commits to an existing PR, **always update the PR body** to reflect the new changes:
+
+```bash
+gh pr edit <pr-number> --body "$(cat <<'EOF'
+...updated body...
+EOF
+)"
+```
+
+The Summary, Changes, and Test plan sections must stay current with all commits on the branch, not just the initial one.
+
+### Responding to review feedback
+
+After pushing the PR, reviewers (human or Copilot) may leave comments. Follow
+the **`pr-review`** skill for the full procedure: checking CI status, replying
+to comments, resolving threads, and re-checking for new Copilot reviews.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: pr-review
+description: >
+  Use when handling pull request reviews, including automated (Copilot) and
+  human reviewer feedback. Use when responding to PR comments, resolving
+  review threads, or updating PRs after review.
+argument-hint: "<PR number>"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# PR Review
+
+This skill defines how to handle PR review feedback in this project.
+
+## Responding to review comments
+
+Every review comment MUST receive a response. Resolve threads only after the
+feedback has been addressed and accepted; leave threads unresolved when disputing
+feedback and escalate to a human reviewer. Unanswered comments or unresolved
+disputed threads block merge.
+
+### Rules
+
+- Address ALL review comments before requesting re-review. Do not leave
+  comments unanswered.
+- Every comment requires a **closing reply**. When the feedback is addressed
+  or accepted, also **resolve the thread** via the GitHub UI or API. When
+  disputing or flagging a false positive, leave the thread unresolved for
+  human escalation.
+- Reply to each comment with a **brief explanation of how it was resolved** and
+  the commit hash (e.g., "Removed the unused imports so Ruff F401 passes.
+  Fixed in abc1234."). Do not reply with only the SHA; explain the fix.
+- If a comment is a false positive or you disagree, reply with a clear
+  technical explanation. Do not resolve the thread. This will require human
+  intervention. Do not dismiss without justification.
+- After pushing fixes, update the PR description to reflect the expanded scope
+  (per the pr-new skill).
+
+### Deferred work MUST be tracked
+
+Any time a review response includes language like "follow-up PR", "subsequent
+PR", "leaving as a follow-up", "future enhancement", "out of scope for this
+PR", or "logging this for later" — you **MUST** create a GitHub issue
+immediately using `gh issue create`. Do not reply to the comment without also
+creating the issue. Include the issue URL in your reply so the reviewer can
+verify tracking.
+
+Untracked follow-ups are invisible debt. If it is worth mentioning, it is
+worth an issue.
+
+```bash
+gh issue create --repo ansible/team-devtools \
+  --title "<type>(scope): <brief description>" \
+  --body "$(cat <<'EOF'
+## Context
+
+<What was the review comment and why it wasn't addressed in this PR>
+
+Flagged in: <link to PR comment thread>
+
+## Proposal
+
+<What should be done>
+
+## References
+
+- PR #N
+EOF
+)"
+```
+
+## Copilot review patterns
+
+Copilot automated reviews surface recurring categories. Address these
+proactively before pushing to avoid review round-trips:
+
+### Supply-chain security
+
+Pin GitHub Actions to commit SHAs instead of mutable tags (`@v1`). Mutable
+tags allow upstream changes to affect CI without review. Use a comment to
+note the original tag:
+
+```yaml
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+```
+
+### Inaccurate documentation
+
+Documentation MUST accurately describe the actual behavior. If a workflow
+triggers on `pull_request` targeting `main`, don't document it as running
+on "every pull request". Be specific about triggers, branches, and conditions.
+
+### Markdown table formatting
+
+Tables must use a single leading `|` on each line. Double leading `||` renders
+as an extra empty column. Validate table rendering before committing.
+
+### Inaccurate comments
+
+Code comments and docstrings MUST accurately describe what the code does. If
+you rename a function, change behavior, or remove functionality, update all
+associated comments in the same commit.
+
+### Secrets in documentation
+
+Never show API keys, tokens, or credentials on command lines in docs or
+examples. Demonstrate env var usage instead. Shell history and process lists
+expose command-line arguments.
+
+### Unused imports (Ruff F401)
+
+Copilot often flags unused imports. With Ruff `F` rules enabled, these fail CI.
+Remove unused imports or use the symbol (e.g. in a type annotation or
+assertion). Prefer trimming the import list over `# noqa: F401` unless the
+import is intentionally side-effect only.
+
+## Workflow
+
+1. **Ensure the PR branch is up to date with upstream main.** Before
+   reviewing or pushing fixes, rebase or merge `upstream/main` into the PR
+   branch. A stale base causes misleading CI results, merge conflicts, and
+   wasted review cycles. If the branch is behind, update it first:
+   ```bash
+   git fetch upstream
+   git rebase upstream/main   # or: git merge upstream/main
+   git push --force-with-lease
+   ```
+2. After pushing a PR, wait for both CI and Copilot review.
+3. Check CI status and read all review comments.
+4. Fix all issues in a single commit (or minimal commits).
+5. Reply to each comment with a brief explanation of how it was resolved and
+   the commit hash (e.g., "Removed unused imports. Fixed in abc1234.").
+6. **Reply to every comment.** Resolve the thread only when the issue is
+   addressed or accepted. Leave disagreement or false-positive threads open
+   for a human reviewer to decide.
+
+### Checking CI status
+
+Always check CI checks as part of the review workflow. Fix failures before
+addressing review comments — a green build is a prerequisite for merge.
+
+```bash
+# List failing checks (replace N with PR number)
+gh pr checks N --json name,state --jq '.[] | select(.state != "SUCCESS" and .state != "PENDING")'
+
+# Get the log link for a specific failed check
+gh pr checks N --json name,state,link --jq '.[] | select(.name == "CHECK_NAME") | .link'
+
+# View failed job logs directly
+gh run view RUN_ID --log-failed 2>&1 | tail -80
+```
+
+Common CI failures and how to fix them:
+
+- **prek (ruff)**: Run `tox -e lint` to reproduce. Long type annotations
+  and function signatures often need line wrapping.
+- **prek (mypy)**: Add type annotations to all new functions. Use the correct
+  `type: ignore` code (e.g., `[assignment]` vs `[method-assign]`). Run
+  `tox -e lint` to verify.
+- **prek (biome)**: Run `tox -e lint` to reproduce. Biome enforces formatting
+  for JSON, Markdown, and JavaScript files.
+- **prek (ansible-lint)**: Run `tox -e lint` to reproduce. Ensure playbooks
+  and roles follow ansible-lint rules.
+- **prek (tombi)**: Run `tox -e lint` to reproduce. TOML files must be
+  formatted with tombi.
+- **test failures**: Run `tox -e py` to reproduce. Update tests when behavior
+  changes.
+
+Do **not** run `ruff`, `mypy`, `pytest`, or `prek` directly — always use tox.
+See the `/tox` skill for the full environment reference.
+
+### Replying to review comments
+
+Post a reply using the REST API. Each reply must state **how** the issue was
+resolved and include the commit hash (not only the SHA):
+
+```bash
+gh api -X POST "repos/ansible/team-devtools/pulls/PR/comments/COMMENT_ID/replies" \
+  -f body="Removed the unused imports so Ruff F401 passes. Fixed in COMMIT_SHA."
+```
+
+To get comment IDs: `gh api repos/ansible/team-devtools/pulls/PR/comments` and
+use each comment's `id`. Alternatively, reply in the GitHub PR UI, then resolve
+threads via GraphQL below.
+
+### Resolving review threads (GraphQL)
+
+**IMPORTANT:** Always use `resolveReviewThread` to resolve threads. Do NOT use
+`minimizeComment` — that hides the comment text but does NOT resolve the review
+thread, leaving it as an unresolved conversation on the PR.
+
+Replace `N` with the PR number and `THREAD_ID` with the `id` from
+`reviewThreads.nodes[].id` (from the list query). Filter nodes where
+`isResolved` is false if you only want to resolve open threads.
+
+```bash
+# List unresolved threads (get thread id for each)
+gh api graphql -f query='{
+  repository(owner: "ansible", name: "team-devtools") {
+    pullRequest(number: N) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved comments(first:1) { nodes { body } } }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, snippet: .comments.nodes[0].body[0:120]}'
+
+# Resolve one thread
+gh api graphql -f query='mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}'
+
+# Resolve multiple threads in a loop
+for tid in "THREAD_ID_1" "THREAD_ID_2"; do
+  gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"${tid}\"}) { thread { isResolved } } }"
+done
+```
+
+7. Update the PR description to include the new commit(s).
+8. If CI failure is unrelated to your changes (e.g., flaky test, transient
+   network issue), fix it anyway — the PR owns the green build.
+
+### After pushing fixes: check for a new Copilot review
+
+Copilot may run again on new commits. Re-check whether it left a new review or
+line comments so you can reply and resolve any new threads.
+
+```bash
+# New Copilot review (replace N with PR number, ISO8601 with last push time)
+gh api repos/ansible/team-devtools/pulls/N/reviews --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .submitted_at > "ISO8601") | {submitted_at, state, body: .body[0:200]}'
+
+# New Copilot line comments (replace N and ISO8601)
+gh api repos/ansible/team-devtools/pulls/N/comments --jq '.[] | select(.user.login == "Copilot" and .created_at > "ISO8601") | {id, created_at, path, body: .body[0:150]}'
+```
+
+If both return nothing, no new Copilot activity. Otherwise, address new
+comments (reply with how it was resolved + commit hash, then resolve threads)
+and repeat this check after the next push.

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: tox
+description: >
+  Reference for running lint, test, build, and doc commands via tox.
+  Agents MUST use tox for all quality gates — never invoke pytest, ruff,
+  mypy, prek, or shell scripts directly. This skill is the canonical
+  lookup table for which tox environment to use.
+argument-hint: "[environment-name]"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# tox — Sole Developer & Agent Orchestration Tool
+
+## Usage
+
+```
+/tox                  # Show full environment reference
+/tox lint             # How to run lint
+/tox py               # How to run tests
+/tox docs             # How to build docs
+/tox <env>            # Lookup any tox environment
+```
+
+tox is the **only** way to run lint, test, build, and doc commands in this
+project. Do not invoke `pytest`, `ruff`, `mypy`, `prek`, or shell scripts
+directly. Every task maps to a `tox -e <env>` command.
+
+## Hard Rules
+
+1. **Never run `pytest` directly.** Use `tox -e py`.
+2. **Never run `ruff`, `mypy`, or `prek` directly.** Use `tox -e lint`.
+3. **Pass extra arguments after `--`.** Example: `tox -e py -- -k test_repos`.
+4. **In CI, use `uvx --with tox-uv tox -e <env>`** instead of installing tox.
+
+## Environment Reference
+
+### Quality gates
+
+| Environment | What it runs | When to use |
+|-------------|-------------|-------------|
+| `tox -e lint` | `prek run --all-files` (ruff, mypy, biome, tombi, codespell, ansible-lint) | Before every commit. Verification step for all tasks. |
+
+### Test suites
+
+| Environment | What it runs | When to use |
+|-------------|-------------|-------------|
+| `tox -e py` | `pytest` with coverage (`--fail-under=43`) | After any code change. |
+| `tox -e py -- -k <pattern>` | Single test or test pattern | Debugging a specific test. |
+| `tox -e py -- --no-cov` | Tests without coverage overhead | Quick iteration. |
+| `tox -e devel` | Tests with newest deps (no lock, prereleases allowed) | Verifying forward compatibility. |
+
+### Documentation
+
+| Environment | What it runs | When to use |
+|-------------|-------------|-------------|
+| `tox -e docs` | `mkdocs build --strict` | After doc changes. |
+
+### Packaging
+
+| Environment | What it runs | When to use |
+|-------------|-------------|-------------|
+| `tox -e pkg` | `python -m build` + `twine check --strict` | Before release. Verify package metadata. |
+
+### Dependency management
+
+| Environment | What it runs | When to use |
+|-------------|-------------|-------------|
+| `tox -e deps` | `prek run deps` + `prek autoupdate` + `tox -e lint` | Bumping all dependencies. |
+
+### Default set
+
+Running `tox` with no `-e` flag executes: `pkg`, `lint`, `docs`, `py`, `devel`.
+This is the full quality gate.
+
+## Common Agent Workflows
+
+### "I changed Python code, what do I run?"
+
+```bash
+tox -e lint              # check style + types
+tox -e py                # run tests
+```
+
+### "I changed documentation"
+
+```bash
+tox -e docs              # build and verify docs
+```
+
+### "I need to run one specific test"
+
+```bash
+tox -e py -- -k test_repos
+tox -e py -- test/test_jira_create_issue.py::test_specific_function
+```
+
+### "I want to verify everything before a PR"
+
+```bash
+tox -e lint
+tox -e py
+```
+
+### "List all available environments"
+
+```bash
+tox l
+```
+
+## Installation
+
+```bash
+uv tool install tox --with tox-uv
+```
+
+## Configuration
+
+All tox configuration lives in `pyproject.toml` under `[tool.tox]`. Environment
+definitions, extras, pass-through env vars, and commands are all there.
+Do not scatter test/lint invocations across Makefiles, scripts, or
+workflow YAML.

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,64 @@
+---
+name: sync-skills
+
+on:
+  schedule:
+    - cron: "7 8 * * 1" # Weekly Monday 08:07 UTC
+  push:
+    branches: [main]
+    paths: [".agents/skills/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    environment: ack
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - ansible/ansible-compat
+          - ansible/ansible-creator
+          - ansible/ansible-dev-environment
+          - ansible/ansible-dev-tools
+          - ansible/ansible-lint
+          - ansible/ansible-navigator
+          - ansible/molecule
+          - ansible/pytest-ansible
+          - ansible/tox-ansible
+          - ansible/vscode-ansible
+    steps:
+      - name: Checkout team-devtools (source)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: source
+          sparse-checkout: .agents/skills
+
+      - name: Checkout target repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ matrix.repo }}
+          token: ${{ secrets.BOT_PAT }}
+          path: target
+
+      - name: Sync skills to target repo
+        run: |
+          mkdir -p target/.agents/skills
+          rsync -a --delete source/.agents/skills/ target/.agents/skills/
+
+      - name: Commit and push if changed
+        working-directory: target
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          git diff --quiet && git diff --cached --quiet && exit 0
+          git config user.name "Ansible Bot"
+          git config user.email "devtools@ansible.com"
+          git add .agents/skills/
+          git commit -m "chore: sync agent skills from team-devtools
+
+          Source: ansible/team-devtools@${SOURCE_SHA}"
+          git push

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -8,7 +8,6 @@ on:
     branches: [main]
     paths: [".agents/skills/**"]
   workflow_dispatch:
-
 permissions:
   contents: read
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 ## Static checks
 
+## Agent Skills
+
+Agent skills are available in `.agents/skills/` and can be invoked by name:
+
+| Skill | Purpose | Invocation |
+|-------|---------|------------|
+| `pr-new` | Prepare and submit a pull request | `/pr-new` |
+| `pr-review` | Handle PR review feedback (Copilot and human) | `/pr-review <PR#>` |
+| `pr-contributor-review` | Review and prepare a contributor's PR | `/pr-contributor-review <PR#>` |
+| `tox` | Tox environment reference (lint, test, docs) | `/tox [env]` |
+
 ## Agents
 
 - `.vscode/extensions.json` file must:


### PR DESCRIPTION
## Summary
- Add 4 agent skills (pr-new, pr-review, pr-contributor-review, tox) adapted from ansible/apme for team-devtools
- Add centralized sync-skills GitHub Actions workflow to propagate skills to 10 consumer repos
- Update AGENTS.md with skills reference table

## Changes
- **`.agents/skills/tox/SKILL.md`** — Tox environment reference adapted to team-devtools envs (lint, py, docs, pkg, devel, deps)
- **`.agents/skills/pr-new/SKILL.md`** — PR submission workflow with quality gates, conventional commits, and PR template
- **`.agents/skills/pr-review/SKILL.md`** — PR review handling: responding to comments, GraphQL thread resolution, Copilot patterns, deferred work tracking
- **`.agents/skills/pr-contributor-review/SKILL.md`** — Contributor PR review checklist: upstream sync, quality gates, description quality
- **`.agents/skills/README.md`** — Skills index
- **`.github/workflows/sync-skills.yml`** — Centralized workflow that syncs skills to 10 repos (weekly + on change + manual dispatch)
- **`AGENTS.md`** — Added Agent Skills section with invocation table

## Key adaptations from apme
- `tox -e unit` → `tox -e py` (team-devtools naming)
- Removed all SDLC/ADR, gRPC, container/pod, rule catalog references
- Updated CI failure patterns for team-devtools hooks (biome, tombi, ansible-lint)
- All repo references point to `ansible/team-devtools`

## Sync workflow details
- Pushes `.agents/skills/` to: ansible-compat, ansible-creator, ansible-dev-environment, ansible-dev-tools, ansible-lint, ansible-navigator, molecule, pytest-ansible, tox-ansible, vscode-ansible
- Triggers: weekly Monday 08:07 UTC, on `.agents/skills/**` changes to main, manual dispatch
- Direct commit to main (markdown-only, non-runtime changes)
- Uses existing `BOT_PAT` from `ack` environment

## Test plan
- [ ] Review all skill files for correctness and no apme-specific references
- [ ] Verify sync-skills workflow YAML is valid
- [ ] After merge, trigger `sync-skills` via `workflow_dispatch` and verify skills appear in a target repo

Related: [AAP-71791](https://redhat.atlassian.net/browse/AAP-71791)