### PR TITLE
fix: stage files before diff check in sync-skills workflow

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -53,10 +53,10 @@ jobs:
         env:
           SOURCE_SHA: ${{ github.sha }}
         run: |
-          git diff --quiet && git diff --cached --quiet && exit 0
+          git add .agents/skills/
+          git diff --quiet --cached && exit 0
           git config user.name "Ansible Bot"
           git config user.email "devtools@ansible.com"
-          git add .agents/skills/
           git commit -m "chore: sync agent skills from team-devtools
 
           Source: ansible/team-devtools@${SOURCE_SHA}"


### PR DESCRIPTION
## Summary
- `git diff --quiet` only detects changes to already-tracked files
- Since `.agents/skills/` is new in all target repos, the files were untracked and invisible to the diff check
- The script exited early on every repo without ever committing or pushing the skills
- Fix: run `git add` first, then check `git diff --cached --quiet` to detect staged changes

## Test plan
- [ ] Merge and trigger `workflow_dispatch` on the sync-skills workflow
- [ ] Verify `.agents/skills/` appears in target repos (e.g. ansible/ansible-lint, ansible/molecule)

Assisted-by: Claude Code