### PR TITLE
fix: add language specifiers to fenced code blocks in agent skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -20,7 +20,7 @@ Agent skills for development and maintenance workflow automation in Ansible Devt
 
 ## Skill Structure
 
-```
+```text
 skills/
 ├── README.md                   ← You are here
 ├── pr-new/

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -58,7 +58,7 @@ Check whether your changes affect areas covered by existing docs. Update any tha
 
 Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
 
-```
+```text
 <type>[optional scope]: <description>
 
 [optional body]

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 ## Usage
 
-```
+```text
 /tox                  # Show full environment reference
 /tox lint             # How to run lint
 /tox py               # How to run tests


### PR DESCRIPTION
## Summary
- Adds `text` language specifier to 3 bare fenced code blocks that fail markdownlint MD040 rule
- Fixes CI lint failures across 8 downstream repos caused by the `sync-skills` workflow pushing these files directly to main

## Files changed
- `.agents/skills/tox/SKILL.md:19` — CLI usage examples
- `.agents/skills/pr-new/SKILL.md:61` — commit message template
- `.agents/skills/README.md:23` — directory tree

## Context
PR #457 added agent skills and a sync workflow that pushes to 10 downstream repos. The sync bypasses PR CI, so the markdownlint violations weren't caught before landing on main. Currently breaking lint in: vscode-ansible, ansible-creator, molecule, ansible-navigator, ansible-compat, ansible-dev-environment, pytest-ansible, and tox-ansible.

## Test plan
- [ ] `markdownlint` passes on all 3 files
- [ ] After merge, `sync-skills` propagates the fix to downstream repos