### PR TITLE
fix: resolve markdown lint failures in agent skill files

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -35,7 +35,7 @@ skills/
 
 ## SKILL.md Format
 
-Each skill has YAML frontmatter:
+Each skill has YAML front matter:
 
 ```yaml
 ---

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -83,12 +83,14 @@ Common types for this project:
 Scopes reflect project areas: `jira`, `check`, `docs`, `ci`, `deps`, `config`.
 
 Examples:
+
 - `feat(jira): add bulk issue creation support`
 - `fix(check): handle missing platform constraints gracefully`
 - `docs: update release process guide`
 - `ci: add Python 3.14 to test matrix`
 
 Include ticket references in the commit footer:
+
 - `Fixes: #123` for GitHub issues
 - `Related: AAP-123` for JIRA tickets
 - Do not use URLs — use plain text references

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -123,11 +123,13 @@ import is intentionally side-effect only.
    reviewing or pushing fixes, rebase or merge `upstream/main` into the PR
    branch. A stale base causes misleading CI results, merge conflicts, and
    wasted review cycles. If the branch is behind, update it first:
+
    ```bash
    git fetch upstream
    git rebase upstream/main   # or: git merge upstream/main
    git push --force-with-lease
    ```
+
 2. After pushing a PR, wait for both CI and Copilot review.
 3. Check CI status and read all review comments.
 4. Fix all issues in a single commit (or minimal commits).
@@ -221,8 +223,8 @@ for tid in "THREAD_ID_1" "THREAD_ID_2"; do
 done
 ```
 
-7. Update the PR description to include the new commit(s).
-8. If CI failure is unrelated to your changes (e.g., flaky test, transient
+1. Update the PR description to include the new commit(s).
+2. If CI failure is unrelated to your changes (e.g., flaky test, transient
    network issue), fix it anyway — the PR owns the green build.
 
 ### After pushing fixes: check for a new Copilot review


### PR DESCRIPTION
## Summary
- Adds missing blank lines before lists in `pr-new/SKILL.md`
- Adds missing blank lines around fenced code block and fixes list numbering in `pr-review/SKILL.md`
- Fixes cspell "frontmatter" → "front matter" in `README.md`

## Context
Follow-up to #461. The MD040 fix resolved bare code fence errors, but downstream repos (vscode-ansible, ansible-creator, molecule) still fail lint due to missing blank lines before lists and incorrect ordered list numbering. Verified locally by running `tox -e lint` / `prek run --all-files` in each affected repo.

**Note:** ansible-navigator has additional failures from prettier + stricter markdownlint (MD030, MD060) that require a separate fix.

## Repos verified locally
- ansible-creator — will pass after sync
- molecule — will pass after sync
- vscode-ansible — will pass after sync
- ansible-compat — already passing
- ansible-dev-environment — already passing
- pytest-ansible — already passing
- tox-ansible — already passing

## Test plan
- [ ] team-devtools lint passes
- [ ] After merge + sync, downstream repo CI goes green