### PR TITLE
fix: inline tox devel commands for tombi-lint compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,9 +213,33 @@ skip_install = true
 [tool.tox.env.devel]
 commands = [
   ["sh", "-c", "uv pip list -q --format=freeze | tr '\\n' ','"],
-  # tox 4 command-ref table; pyproject schema only allows arrays of argv (tox-dev/tox#3823)
-  # tombi: lint.rules.type-mismatch.disabled = true
-  { extend = true, of = ["tool", "tox", "env_run_base", "commands"], replace = "ref" },
+  # Inlined from [tool.tox.env_run_base] commands so tombi-lint accepts the file (the
+  # tox 4 command-ref `{ extend, of, replace = "ref" }` form matches two JSON-schema branches).
+  # NOTE: If env_run_base commands change, update this section accordingly.
+  [
+    "python",
+    "-c",
+    "import pathlib; pathlib.Path(\"{env_site_packages_dir}/cov.pth\").write_text(\"import coverage; coverage.process_startup()\")",
+  ],
+  [
+    "coverage",
+    "run",
+    "-m",
+    "pytest",
+    { default = [
+      "-ra",
+      "-n",
+      "auto",
+      "--showlocals",
+      "--doctest-modules",
+      "--durations=10",
+      "--junitxml=./junit.xml",
+    ], extend = true, replace = "posargs" },
+  ],
+  ["coverage", "combine", "-q"],
+  ["coverage", "xml", "-o", "{env_dir}/coverage.xml", "--fail-under=0"],
+  ["coverage", "lcov", "-q", "--fail-under=0"],
+  ["coverage", "report"],
   ["git", "restore", "uv.lock"],
 ]
 description = "Run the tests with newest dependencies (no lock and allowing prereleases)"


### PR DESCRIPTION
## Summary

The `lint` job in `test.yml` runs prek, which runs **tombi-lint** on `pyproject.toml`. 

That step failed with:

`Error: 1 of 2 schemas must be matched, but found 2 matched schemas`

at the tox 4 **command reference** table under `[tool.tox.env.devel]`  
(`{ extend = true, of = ["tool", "tox", "env_run_base", "commands"], replace = "ref" }`).

Tox accepts that form, but Tombi's `tool.tox` JSON schema treats it as matching two `oneOf` branches.

## Change

- Replace the command-ref with an **explicit copy** of the same `commands` as `[tool.tox.env_run_base]`, plus the existing `devel`-only first/last steps.
- **Runtime behavior** for `tox -e devel` stays the same (`devel` still bases on `env_run_base` for `commands_pre`, env, etc.).

## Verification

- `uv run tombi lint pyproject.toml`
- `uv run prek run --config .pre-commit-config.yaml --all-files`

_Assisted-by: Claude Code_
