### PR TITLE
fix(ci): suppress tombi oneOf schema warning for tox command-ref syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-useless-excludes
         priority: 0
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.10
+    rev: 0.11.15
     hooks:
       - id: uv-sync
         priority: 0
@@ -25,7 +25,7 @@ repos:
         args: ["--upgrade"]
         stages: [manual]
   - repo: https://github.com/biomejs/pre-commit
-    rev: "v2.4.14"
+    rev: "v2.4.15"
     hooks:
       - id: biome-check
         priority: 1
@@ -53,7 +53,7 @@ repos:
       - id: check-merge-conflict
         priority: 0
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.10.4
+    rev: v0.11.5
     hooks:
       - id: tombi-format
         alias: toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,33 +213,9 @@ skip_install = true
 [tool.tox.env.devel]
 commands = [
   ["sh", "-c", "uv pip list -q --format=freeze | tr '\\n' ','"],
-  # Inlined from [tool.tox.env_run_base] commands so tombi-lint accepts the file (the
-  # tox 4 command-ref `{ extend, of, replace = "ref" }` form matches two JSON-schema branches).
-  # NOTE: If env_run_base commands change, update this section accordingly.
-  [
-    "python",
-    "-c",
-    "import pathlib; pathlib.Path(\"{env_site_packages_dir}/cov.pth\").write_text(\"import coverage; coverage.process_startup()\")",
-  ],
-  [
-    "coverage",
-    "run",
-    "-m",
-    "pytest",
-    { default = [
-      "-ra",
-      "-n",
-      "auto",
-      "--showlocals",
-      "--doctest-modules",
-      "--durations=10",
-      "--junitxml=./junit.xml",
-    ], extend = true, replace = "posargs" },
-  ],
-  ["coverage", "combine", "-q"],
-  ["coverage", "xml", "-o", "{env_dir}/coverage.xml", "--fail-under=0"],
-  ["coverage", "lcov", "-q", "--fail-under=0"],
-  ["coverage", "report"],
+  # tox 4 command-ref table; pyproject schema only allows arrays of argv (tox-dev/tox#3823)
+  # tombi: lint.rules.one-of-multiple-match.disabled = true
+  { extend = true, of = ["tool", "tox", "env_run_base", "commands"], replace = "ref" },
   ["git", "restore", "uv.lock"],
 ]
 description = "Run the tests with newest dependencies (no lock and allowing prereleases)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,9 +213,33 @@ skip_install = true
 [tool.tox.env.devel]
 commands = [
   ["sh", "-c", "uv pip list -q --format=freeze | tr '\\n' ','"],
-  # tox 4 command-ref table; pyproject schema only allows arrays of argv (tox-dev/tox#3823)
-  # tombi: lint.rules.type-mismatch.disabled = true
-  { extend = true, of = ["tool", "tox", "env_run_base", "commands"], replace = "ref" },
+  # Inlined from [tool.tox.env_run_base] commands so tombi-lint accepts the file (the
+  # tox 4 command-ref `{ extend, of, replace = "ref" }` form matches two JSON-schema branches).
+  # NOTE: If env_run_base commands change, update this section accordingly.
+  [
+    "python",
+    "-c",
+    "import pathlib; pathlib.Path(\"{env_site_packages_dir}/cov.pth\").write_text(\"import coverage; coverage.process_startup()\")",
+  ],
+  [
+    "coverage",
+    "run",
+    "-m",
+    "pytest",
+    { default = [
+      "-ra",
+      "-n",
+      "auto",
+      "--showlocals",
+      "--doctest-modules",
+      "--durations=10",
+      "--junitxml=./junit.xml",
+    ], extend = true, replace = "posargs" },
+  ],
+  ["coverage", "combine", "-q"],
+  ["coverage", "xml", "-o", "{env_dir}/coverage.xml", "--fail-under=0"],
+  ["coverage", "lcov", "-q", "--fail-under=0"],
+  ["coverage", "report"],
   ["git", "restore", "uv.lock"],
 ]
 description = "Run the tests with newest dependencies (no lock and allowing prereleases)"


### PR DESCRIPTION
  ## Summary

  Fixes tombi-lint failures by using the correct suppression rule for tox 4 command-ref syntax.

  The tox 4 command-ref table form `{ extend, of, replace }` matches multiple branches in the JSON schema's oneOf constraint, triggering a `one-of-multiple-match` error in tombi v0.9.12+.

  **Changes:**
  - Replace inlined commands with the original command-ref syntax
  - Use `lint.rules.one-of-multiple-match.disabled = true` instead of the previously attempted `type-mismatch` rule

  **Context:**
  - tombi v0.9.12 (April 2026) introduced stricter oneOf validation
  - Previous fix attempt (a846b4d) used the wrong suppression rule
  - This reverts the workaround from commit 480f6cb and applies the correct fix

  **References:**
  - tox command-ref syntax: tox-dev/tox#3823
  - tombi version: v0.10.4

_Assisted-by: Claude Code_