### PR TITLE
fix(ci): use PRs instead of direct push in sync-skills workflow

### DIFF
--- a/.github/workflows/sync_skills.yml
+++ b/.github/workflows/sync_skills.yml
@@ -48,16 +48,37 @@ jobs:
           mkdir -p target/.agents/skills
           rsync -a --delete source/.agents/skills/ target/.agents/skills/
 
-      - name: Commit and push if changed
+      - name: Create PR if changed
         working-directory: target
         env:
           SOURCE_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           git add .agents/skills/
           git diff --quiet --cached && exit 0
+
+          REPO_NAME="${{ matrix.repo }}"
+          BRANCH="chore/sync-agent-skills"
+
           git config user.name "Ansible Bot"
           git config user.email "devtools@ansible.com"
+
+          # reuse existing branch or create a new one
+          git checkout -B "${BRANCH}"
           git commit -m "chore: sync agent skills from team-devtools
 
           Source: ansible/team-devtools@${SOURCE_SHA}"
-          git push
+          git push --force origin "${BRANCH}"
+
+          # update existing PR or open a new one
+          if gh pr view "${BRANCH}" --repo "${REPO_NAME}" > /dev/null 2>&1; then
+            echo "PR already exists for ${BRANCH}, force-pushed update."
+          else
+            gh pr create \
+              --repo "${REPO_NAME}" \
+              --head "${BRANCH}" \
+              --title "chore: sync agent skills from team-devtools" \
+              --body "Automated sync of \`.agents/skills/\` from \`ansible/team-devtools\`.
+
+          Source: ansible/team-devtools@${SOURCE_SHA}"
+          fi


### PR DESCRIPTION
  Summary
  
  - Change sync-skills workflow to open PRs on target repos instead of pushing directly to their main branch
  - Rename workflow file from sync-skills.yml to sync_skills.yml

  Details

  The sync-skills workflow currently commits and pushes directly to the main branch of all 10 downstream repos
  as Ansible Bot. This bypasses any branch protection review requirements.

  This change makes the bot:
  1. Create a chore/sync-agent-skills branch on the target repo
  2. Push the sync commit there
  3. Open a PR via gh pr create
  4. If a PR already exists for that branch, force-push the update instead of opening a duplicate

  No changes to triggers (weekly cron, on skills path change, manual dispatch), target repo list, rsync logic,
  or bot identity.

  Test plan

  - Trigger workflow manually via workflow_dispatch and verify PRs are created on target repos
  - Trigger again with no skill changes and verify early exit (git diff --quiet)
  - Trigger again with skill changes while PR exists and verify it updates the existing PR instead of creating a
   new one

Assisted-By: Claude Code