### PR TITLE
feat: add agent skills for ansible-creator, ansible-lint, and ade

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -28,11 +28,25 @@ Agent skills for development and maintenance workflow automation in Ansible Devt
 |-------|---------|-----------|
 | `tox` | tox environment reference (lint, test, docs, pkg) | `[environment-name]` |
 
+### Ansible Developer Tools
+
+| Skill | Purpose | Arguments |
+|-------|---------|-----------|
+| `ansible-creator` | Scaffold collections, playbooks, EEs, plugins | `[subcommand]` |
+| `ansible-lint` | Ansible playbook/role/collection linting reference | `[options]` |
+| `ade` | Development environment setup with ansible-dev-environment | `[subcommand]` |
+
 ## Skill Structure
 
 ```text
 skills/
 ├── README.md                   ← You are here
+├── ade/
+│   └── SKILL.md
+├── ansible-creator/
+│   └── SKILL.md
+├── ansible-lint/
+│   └── SKILL.md
 ├── diagnose-ci/
 │   └── SKILL.md
 ├── fix-bot-prs/

--- a/.agents/skills/ade/SKILL.md
+++ b/.agents/skills/ade/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ade
+description: >
+  Reference for ansible-dev-environment (ade), a pip-like installer for
+  Ansible collections with isolated virtual environments. Use ade to set up
+  development environments that install both Python and collection
+  dependencies, with proper symlinks for editable collection development.
+argument-hint: "[subcommand]"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# ade — Ansible Development Environment Manager
+
+## Usage
+
+```text
+/ade                    # Show full subcommand reference
+/ade install            # How to set up a dev environment
+/ade uninstall          # How to tear down
+```
+
+ade (ansible-dev-environment) is a pip-like installer for Ansible collections
+that creates isolated virtual environments. It reads `galaxy.yml` to determine
+collection metadata and installs both Python and Ansible collection
+dependencies.
+
+## Hard Rules
+
+1. **Always use `--venv <path>`** to isolate the environment. Never install into the system Python.
+2. **`galaxy.yml` must be present.** ade reads it for collection metadata — the command must be run from a directory containing `galaxy.yml` or the path must point to one.
+3. **Use `-e` (editable install) for development.** This symlinks the collection into site-packages so changes are reflected immediately.
+4. **Activate the venv after install.** ade creates the environment but does not activate it — run `source <venv>/bin/activate` after install.
+
+## Subcommand Reference
+
+| Command | What it does | Example |
+|---------|-------------|---------|
+| `ade install -e .[test] --venv .venv` | Editable install with test extras | Set up a collection for development and testing |
+| `ade install -e .[dev,test] --venv .venv` | Editable install with multiple extras | Include both dev and test dependencies |
+| `ade install -e . --venv .venv` | Editable install without extras | Minimal development setup |
+| `ade uninstall <namespace>.<name> --venv .venv` | Remove collection from venv | `ade uninstall ansible.scm --venv .venv` |
+
+## Key Behaviors
+
+| Behavior | Detail |
+|----------|--------|
+| Uses `uv` when available | Falls back to pip if uv is not installed. Set `SKIP_UV=1` to force pip. |
+| Editable installs (`-e`) | Symlinks the collection into site-packages for live development |
+| Collection dependencies | Reads `galaxy.yml` `dependencies` and installs from Galaxy |
+| Python dependencies | Processes `requirements.txt` and `test-requirements.txt` |
+| Requires ansible-core | Must be pre-installed in the target venv or system |
+
+## Common Agent Workflows
+
+### "I need to set up a collection for local development"
+
+```bash
+git clone <collection_repo>
+cd <collection_repo>
+ade install -e .[test] --venv .venv
+source .venv/bin/activate
+```
+
+### "I need to tear down and rebuild the environment"
+
+```bash
+rm -rf .venv
+ade install -e .[test] --venv .venv
+source .venv/bin/activate
+```
+
+### "I cloned a collection repo and want to run tests"
+
+```bash
+ade install -e .[test] --venv .venv
+source .venv/bin/activate
+tox -e py                   # see the /tox skill
+```
+
+### "ade is using pip but I want it to use uv"
+
+Ensure `uv` is installed and available on `PATH`. ade will use it
+automatically. To force pip instead, set `SKIP_UV=1`:
+
+```bash
+SKIP_UV=1 ade install -e .[test] --venv .venv
+```
+
+## Installation
+
+```bash
+pip3 install ansible-dev-tools       # recommended: includes all devtools
+pip3 install ansible-dev-environment  # standalone
+```
+
+## Configuration
+
+ade reads `galaxy.yml` at the collection root for metadata, dependencies,
+and extras. There is no separate ade configuration file. Ensure `galaxy.yml`
+is present and valid before running ade commands.

--- a/.agents/skills/ansible-creator/SKILL.md
+++ b/.agents/skills/ansible-creator/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ansible-creator
+description: >
+  Reference for scaffolding Ansible content with ansible-creator.
+  Use ansible-creator to initialize new collections, playbook projects,
+  and execution environments, or to add plugins and resources to existing
+  projects. This skill is the canonical lookup table for which subcommand
+  and flags to use.
+argument-hint: "[subcommand]"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# ansible-creator — Ansible Content Scaffolding Tool
+
+## Usage
+
+```text
+/ansible-creator                  # Show full subcommand reference
+/ansible-creator init             # How to scaffold new projects
+/ansible-creator add              # How to add plugins/resources
+```
+
+ansible-creator scaffolds Ansible content projects. Use `init` to create new
+projects from scratch and `add` to extend existing ones with plugins or
+resources.
+
+## Hard Rules
+
+1. **Always use `namespace.name` format** for `init collection` and `init playbook`.
+2. **Never scaffold into a non-empty directory** without `-o/--overwrite` — the command will fail.
+3. **After scaffolding, run `tox -e lint`** to verify the generated content passes quality gates. See the `/tox` skill.
+4. **`add plugin` requires the collection root** — the path must point to the directory containing `galaxy.yml`.
+
+## Subcommand Reference
+
+### Initialize projects
+
+| Command | What it creates | Example |
+|---------|----------------|---------|
+| `ansible-creator init collection <ns>.<name> <path>` | Full collection skeleton (plugins, roles, tests, docs, galaxy.yml) | `ansible-creator init collection myorg.network ~/collections/ansible_collections` |
+| `ansible-creator init playbook <ns>.<name> <path>` | Playbook project structure | `ansible-creator init playbook myorg.deploy ~/projects/deploy` |
+| `ansible-creator init execution_env <path>` | Execution environment definition files | `ansible-creator init execution_env ~/ee-project` |
+
+### Add to existing projects
+
+#### Resources
+
+| Command | What it adds |
+|---------|-------------|
+| `ansible-creator add resource devcontainer <path>` | Dev container configuration |
+| `ansible-creator add resource devfile <path>` | Devfile for cloud IDEs |
+| `ansible-creator add resource execution-environment <path>` | Sample EE YAML template |
+| `ansible-creator add resource play-argspec <path>` | Playbook argument specification examples |
+| `ansible-creator add resource role <path>` | New role skeleton |
+
+#### Plugins
+
+| Command | What it adds | Example |
+|---------|-------------|---------|
+| `ansible-creator add plugin action <name> <coll-path>` | Action plugin | `ansible-creator add plugin action my_action .` |
+| `ansible-creator add plugin filter <name> <coll-path>` | Filter plugin | `ansible-creator add plugin filter my_filter .` |
+| `ansible-creator add plugin lookup <name> <coll-path>` | Lookup plugin | `ansible-creator add plugin lookup my_lookup .` |
+| `ansible-creator add plugin module <name> <coll-path>` | Module plugin | `ansible-creator add plugin module my_module .` |
+| `ansible-creator add plugin test <name> <coll-path>` | Test plugin | `ansible-creator add plugin test my_test .` |
+
+## Common Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-o` / `--overwrite` | Overwrite existing files |
+| `-no` / `--no-overwrite` | Fail if destination exists (default) |
+| `--json` | Output in JSON format |
+| `-v` | Increase verbosity (up to `-vvv`) |
+| `--log-file <path>` | Write log to file |
+| `--na` / `--no-ansi` | Disable colored output |
+| `--ll` / `--log-level` | Set logging level (debug, info, warning, error, critical) |
+
+## Common Agent Workflows
+
+### "I need to start a new Ansible collection"
+
+```bash
+ansible-creator init collection myorg.mynetwork ~/collections/ansible_collections
+cd ~/collections/ansible_collections/myorg/mynetwork
+tox -e lint
+```
+
+### "I need to add a module plugin to an existing collection"
+
+```bash
+cd /path/to/collection       # must contain galaxy.yml
+ansible-creator add plugin module my_new_module .
+```
+
+### "I need to scaffold an execution environment"
+
+```bash
+ansible-creator init execution_env ~/ee-project
+```
+
+### "The target directory already has files"
+
+Use `--overwrite` to replace existing files, or choose a clean path:
+
+```bash
+ansible-creator init collection myorg.mynetwork ~/collections/ansible_collections --overwrite
+```
+
+## Installation
+
+```bash
+pip3 install ansible-dev-tools   # recommended: includes all devtools
+pip3 install ansible-creator     # standalone
+```
+
+## Configuration
+
+ansible-creator does not use a configuration file. All options are passed as
+CLI flags. Scaffolded projects may include their own `pyproject.toml`,
+`galaxy.yml`, and `tox.ini` for downstream configuration.

--- a/.agents/skills/ansible-lint/SKILL.md
+++ b/.agents/skills/ansible-lint/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: ansible-lint
+description: >
+  Reference for linting Ansible playbooks, roles, and collections with
+  ansible-lint. Agents should prefer tox -e lint when available, but this
+  skill provides the canonical reference for ansible-lint options, profiles,
+  rule suppression, and configuration when direct invocation is needed or
+  when understanding lint output.
+argument-hint: "[options]"
+user-invocable: true
+metadata:
+  author: Ansible DevTools Team
+  version: 1.0.0
+---
+
+# ansible-lint — Ansible Playbook & Role Linter
+
+## Usage
+
+```text
+/ansible-lint                  # Show full option reference
+/ansible-lint profiles         # Profile progression reference
+/ansible-lint suppress         # How to suppress rules
+/ansible-lint config           # Configuration file reference
+```
+
+ansible-lint checks playbooks, roles, and collections against best-practice
+rules. In DevTools repos, prefer `tox -e lint` which runs ansible-lint as
+part of the full quality gate. Use this skill to understand lint output,
+choose profiles, or configure suppression.
+
+## Hard Rules
+
+1. **In DevTools repos, prefer `tox -e lint`** over running `ansible-lint` directly. See the `/tox` skill.
+2. **Always run from the project root.** ansible-lint uses the working directory to locate configuration, roles, and dependencies.
+3. **Review `--fix` output before committing.** Never auto-fix and commit blindly.
+4. **Never use blanket `# noqa`** without a rule ID. Always use `# noqa: rule-id[subrule]`.
+5. **Do not lower the profile to silence violations** — fix the violations or use targeted suppression.
+
+## Profile Reference
+
+Profiles are progressive — each level includes all rules from lower levels.
+
+| Profile | Strictness | Typical use |
+|---------|-----------|-------------|
+| `min` | Lowest | Critical syntax/parse errors only — legacy code migration |
+| `basic` | Low | min + basic best practices — getting started |
+| `moderate` | Medium | basic + style and naming — active development |
+| `safety` | High | moderate + security patterns — production-bound code |
+| `shared` | Higher | safety + community standards — shared/published content |
+| `production` | Highest | All rules — production deployments |
+
+## Key Options
+
+| Option | Purpose | Example |
+|--------|---------|---------|
+| `--profile <name>` | Set strictness level | `ansible-lint --profile production` |
+| `--fix [WRITE_LIST]` | Auto-fix violations | `ansible-lint --fix` |
+| `-f <format>` | Output format (brief, full, json, sarif, pep8) | `ansible-lint -f json` |
+| `-t <tags>` | Include only matching rule tags | `ansible-lint -t yaml` |
+| `-x <rules>` | Skip specific rules | `ansible-lint -x yaml[truthy]` |
+| `-w <rules>` | Treat as warnings (non-blocking) | `ansible-lint -w name[casing]` |
+| `--enable-list` | Activate optional rules | `ansible-lint --enable-list no-log-password` |
+| `-s` / `--strict` | Warnings become errors | `ansible-lint --strict` |
+| `--offline` | Skip galaxy dep install and schema refresh | `ansible-lint --offline` |
+| `--generate-ignore` | Create/update .ansible-lint-ignore | `ansible-lint --generate-ignore` |
+| `-c <file>` | Use specific config file | `ansible-lint -c .config/ansible-lint.yml` |
+| `--project-dir <dir>` | Set project root directory | `ansible-lint --project-dir ./roles/myrole` |
+| `--exclude <path>` | Skip directories or files (repeatable) | `ansible-lint --exclude tests/` |
+
+## Suppression Methods
+
+### Inline suppression
+
+Add `# noqa: rule-id` to the end of the offending line. Multiple rules can be space-separated:
+
+```yaml
+- name: Example task  # noqa: command-instead-of-module no-changed-when
+  command: echo hello
+```
+
+### Ignore file
+
+Create `.ansible-lint-ignore` (or `.config/ansible-lint-ignore.txt`) with one entry per line:
+
+```text
+playbooks/legacy.yml yaml[truthy]
+roles/old_role/tasks/main.yml name[casing]
+```
+
+### Config file skip/warn lists
+
+```yaml
+skip_list:
+  - yaml[truthy]
+warn_list:
+  - name[casing]
+```
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `.ansible-lint` | Primary config (YAML) |
+| `.ansible-lint.yml` / `.ansible-lint.yaml` | Alternative names |
+| `.config/ansible-lint.yml` | XDG-style location |
+| `.ansible-lint-ignore` | Per-file rule suppression |
+
+Example configuration:
+
+```yaml
+profile: moderate
+skip_list:
+  - yaml[truthy]
+warn_list:
+  - name[casing]
+exclude_paths:
+  - .cache/
+  - .tox/
+offline: false
+```
+
+## Common Agent Workflows
+
+### "I need to understand a lint failure"
+
+Read the rule ID from the output (e.g., `yaml[truthy]`). Check the project
+profile in `.ansible-lint` or `.ansible-lint.yml`. Decide whether to fix the
+violation or add targeted suppression.
+
+### "I want to lint only specific files"
+
+```bash
+ansible-lint playbooks/site.yml roles/myrole/
+```
+
+### "I need to auto-fix violations"
+
+```bash
+ansible-lint --fix
+git diff                     # review every change before committing
+```
+
+### "I need to suppress a rule for one file"
+
+```bash
+echo 'playbooks/legacy.yml yaml[truthy]' >> .ansible-lint-ignore
+```
+
+### "I want to check what profile the project uses"
+
+Look for the `profile:` key in `.ansible-lint`, `.ansible-lint.yml`, or
+`.config/ansible-lint.yml` at the project root.
+
+## Installation
+
+```bash
+pip3 install ansible-dev-tools   # recommended: includes all devtools
+pip3 install ansible-lint        # standalone
+```
+
+## Configuration
+
+ansible-lint configuration lives in `.ansible-lint`, `.ansible-lint.yml`, or
+`.config/ansible-lint.yml` at the project root. The cache directory defaults
+to `{project_dir}/.cache/` and should be added to `.gitignore`. Environment
+variables like `ANSIBLE_LINT_CUSTOM_RULESDIR` and `ANSIBLE_LINT_IGNORE_FILE`
+can override defaults.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ Agent skills are available in `.agents/skills/` and can be invoked by name:
 | `pr-review` | Handle PR review feedback (Copilot and human) | `/pr-review <PR#>` |
 | `pr-contributor-review` | Review and prepare a contributor's PR | `/pr-contributor-review <PR#>` |
 | `tox` | Tox environment reference (lint, test, docs) | `/tox [env]` |
+| `ansible-creator` | Scaffold Ansible content (collections, playbooks, EEs, plugins) | `/ansible-creator [subcommand]` |
+| `ansible-lint` | Ansible linting reference (profiles, suppression, config) | `/ansible-lint [options]` |
+| `ade` | Development environment setup (ansible-dev-environment) | `/ade [subcommand]` |
 
 ## Agents
 


### PR DESCRIPTION
## Summary

- Add three new agent skill files for Ansible developer tools under `.agents/skills/`:
  - **ansible-creator**: scaffolding tool reference covering `init` and `add` subcommands for collections, playbooks, execution environments, plugins, and resources
  - **ansible-lint**: linting reference covering profiles, CLI options, rule suppression methods, and configuration
  - **ade**: development environment manager reference covering `install`/`uninstall` workflows with virtual environments
- Update `.agents/skills/README.md` with new "Ansible Developer Tools" section and updated directory tree
- Update `AGENTS.md` skills table with the three new entries

All skills follow the established SKILL.md pattern (YAML frontmatter, Usage, Hard Rules, reference tables, Common Agent Workflows, Installation, Configuration).

## Test plan

- [ ] Verify all three SKILL.md files have valid YAML frontmatter
- [ ] Verify README.md directory tree matches actual directory structure
- [ ] Verify AGENTS.md skills table includes all new entries
- [ ] Run `tox -e lint` — passes clean

https://redhat.atlassian.net/browse/AAP-74992

Assisted-by: Claude Code