### PR TITLE
fix: update codecov-action to v6.0.2 for GPG key migration

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Upload coverage data to codecov.io
         id: upload-coverage
         if: ${{ !cancelled() && hashFiles('**/coverage.xml') != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@8cad3ba95e5920c42f44492e54bc9639cba47959 # v6.0.2
         with:
           name: ${{ matrix.name }}
           fail_ci_if_error: true
@@ -268,7 +268,7 @@ jobs:
       - name: Upload test results to codecov.io
         id: upload-test-results
         if: ${{ !cancelled() && hashFiles('junit.xml') != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@8cad3ba95e5920c42f44492e54bc9639cba47959 # v6.0.2
         with:
           fail_ci_if_error: true
           name: ${{ matrix.name }}


### PR DESCRIPTION
## Summary
Updates `codecov/codecov-action` pin from v6.0.0 to v6.0.2 to fix GPG signature verification failures caused by Codecov migrating their Keybase account from `codecovsecurity` to `codecovsecops` (codecov/codecov-action#1956).

v6.0.2 is a drop-in replacement. All repos using this reusable workflow will be unblocked automatically once merged.
