### PR TITLE
fix: disable bot auto-approval of dependency PRs

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -82,7 +82,7 @@ jobs:
           # label-operator: NOT
 
       # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request
-      - name: Enable auto-merge and approve PRs from safe bots
+      - name: Enable auto-merge for PRs from safe bots
         # do not use github.actor as this can be someone else than the PR author
         if: >
           env.BOT_PAT != null &&
@@ -94,7 +94,6 @@ jobs:
         run: |
           set -e
           gh pr merge --auto --squash "$PR_URL"
-          gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ env.BOT_PAT }}


### PR DESCRIPTION
## Summary

- Removes the `gh pr review --approve` call from the shared `ack.yml` workflow for bot-authored PRs (renovate, dependabot, pre-commit-ci)
- Retains `gh pr merge --auto --squash` so PRs will still auto-merge once CI passes **and** a human approves
- This affects all repos that consume this reusable workflow

## Why

The current flow allows Renovate PRs to merge with zero human oversight:

1. Renovate opens a PR
2. The `ack` workflow auto-approves via `ansibuddy`'s PAT
3. CI passes → Renovate auto-merges

Since `ansibuddy` is a member of `@ansible/devtools` (CODEOWNERS), its approval satisfies branch protection's "1 required approving review" rule. This means dependency updates — including potentially compromised packages — merge without any human ever reviewing them.

## What changes

| Before | After |
|--------|-------|
| Bot PR → auto-approve + auto-merge | Bot PR → auto-merge (pending human approval) |
| No human review required | Human must approve before merge proceeds |

## Impact

- All 12+ ADT repos using this shared workflow will now require a human to approve Renovate/Dependabot PRs
- The `/renovate-review` agent skill provides an efficient workflow for batch-reviewing these PRs with vulnerability scanning

## Test plan

- [ ] Verify existing open Renovate PRs no longer get auto-approved on next push/rebase
- [ ] Confirm auto-merge still activates (PR merges after human approves + CI passes)
- [ ] Validate that non-bot PRs are unaffected (the `if` condition is unchanged)