### PR TITLE
feat: add unified PR security check workflow

### DIFF
--- a/.github/scripts/dep-check.py
+++ b/.github/scripts/dep-check.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Dependency vulnerability scanner for PR checks.
+
+Parses dependency file diffs, queries OSV.dev for known vulnerabilities,
+and outputs a markdown comment body for posting to the PR.
+
+Usage:
+    python dep-check.py --diff <diff_file> [--output <output_file>]
+
+If --diff is "-", reads from stdin.
+Exit code 0 = clean, 1 = vulnerabilities found, 2 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
+OSV_BATCH_SIZE = 100
+OSV_TIMEOUT = 30
+COMMENT_MARKER = "<!-- dep-check-result -->"
+MAX_ADVISORIES_PER_PKG = 5
+
+DEP_FILE_PATTERNS: set[str] = {
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "pyproject.toml",
+    "setup.cfg",
+    "requirements.txt",
+    "uv.lock",
+    "Pipfile.lock",
+}
+
+
+def _write_output(content: str, output_path: str) -> None:
+    """Write content to output path or stdout."""
+    if output_path == "-":
+        sys.stdout.write(content)
+        sys.stdout.write("\n")
+    else:
+        Path(output_path).write_text(content)
+
+
+def is_dep_file(path: str) -> bool:
+    """Return True if the path is a recognized dependency file."""
+    basename = path.rsplit("/", maxsplit=1)[-1]
+    if basename in DEP_FILE_PATTERNS:
+        return True
+    if basename.startswith("requirements") and basename.endswith(".txt"):
+        return True
+    return basename.endswith(".lock") or "pnpm-lock" in path
+
+
+def detect_dep_files_in_diff(diff_text: str) -> list[str]:
+    """Extract dependency file paths from a unified diff."""
+    files = []
+    for match in re.finditer(r"^diff --git a/(.+?) b/(.+?)$", diff_text, re.MULTILINE):
+        path = match.group(2)
+        if is_dep_file(path):
+            files.append(path)
+    return list(set(files))
+
+
+def parse_uv_lock_diff(diff_text: str) -> list[dict[str, str]]:
+    """Parse uv.lock diff for package version changes."""
+    changes: list[dict[str, str]] = []
+    lines = diff_text.split("\n")
+    current_pkg: str | None = None
+    old_ver: str | None = None
+    new_ver: str | None = None
+
+    for line in lines:
+        name_match = re.match(r'^[\s]*name = "(.+)"', line)
+        if name_match:
+            current_pkg = name_match.group(1)
+            old_ver = None
+            new_ver = None
+
+        if current_pkg:
+            old_match = re.match(r'^-version = "(.+)"', line)
+            if old_match:
+                old_ver = old_match.group(1)
+            new_match = re.match(r'^\+version = "(.+)"', line)
+            if new_match:
+                new_ver = new_match.group(1)
+
+            if old_ver and new_ver:
+                changes.append(
+                    {
+                        "name": current_pkg,
+                        "oldVersion": old_ver,
+                        "newVersion": new_ver,
+                        "ecosystem": "PyPI",
+                    }
+                )
+                current_pkg = None
+                old_ver = None
+                new_ver = None
+
+    return changes
+
+
+def parse_pnpm_lock_diff(diff_text: str) -> list[dict[str, str]]:
+    """Parse pnpm-lock.yaml diff for version changes."""
+    changes: list[dict[str, str]] = []
+    lines = diff_text.split("\n")
+    current_pkg: str | None = None
+
+    for i, line in enumerate(lines):
+        pkg_match = re.match(r"^\s{4,8}'?(@?[\w/.@-]+)'?:", line)
+        if pkg_match and "specifier" not in line and "version" not in line:
+            current_pkg = pkg_match.group(1).rstrip(":")
+
+        if line.startswith("-") and "version:" in line and current_pkg:
+            ver_match = re.search(r"(\d+\.\d+[\d.]*)", line)
+            if ver_match:
+                old_v = ver_match.group(1)
+                if (
+                    i + 1 < len(lines)
+                    and lines[i + 1].startswith("+")
+                    and "version:" in lines[i + 1]
+                ):
+                    new_match = re.search(r"(\d+\.\d+[\d.]*)", lines[i + 1])
+                    if new_match and new_match.group(1) != old_v:
+                        changes.append(
+                            {
+                                "name": current_pkg,
+                                "oldVersion": old_v,
+                                "newVersion": new_match.group(1),
+                                "ecosystem": "npm",
+                            }
+                        )
+
+    seen: set[str] = set()
+    deduped: list[dict[str, str]] = []
+    for c in changes:
+        key = f"{c['name']}:{c['oldVersion']}:{c['newVersion']}"
+        if key not in seen:
+            seen.add(key)
+            deduped.append(c)
+    return deduped
+
+
+def parse_pyproject_diff(diff_text: str) -> list[dict[str, str]]:
+    """Parse pyproject.toml diff for version changes."""
+    changes: list[dict[str, str]] = []
+    lines = diff_text.split("\n")
+
+    for i, line in enumerate(lines):
+        if line.startswith("-") and not line.startswith("---"):
+            old_match = re.search(r'"([\w][\w.-]*)([><=!~]+)([\d.]+\*?)"', line)
+            if old_match and i + 1 < len(lines):
+                next_line = lines[i + 1]
+                if next_line.startswith("+"):
+                    new_match = re.search(
+                        r'"([\w][\w.-]*)([><=!~]+)([\d.]+\*?)"', next_line
+                    )
+                    if new_match and new_match.group(1) == old_match.group(1):
+                        changes.append(
+                            {
+                                "name": old_match.group(1),
+                                "oldVersion": old_match.group(3),
+                                "newVersion": new_match.group(3),
+                                "ecosystem": "PyPI",
+                            }
+                        )
+    return changes
+
+
+def parse_package_json_diff(diff_text: str) -> list[dict[str, str]]:
+    """Parse package.json / package-lock.json diff for version changes."""
+    changes: list[dict[str, str]] = []
+    lines = diff_text.split("\n")
+    pkg_ver_re = re.compile(r'"([@\w/.-]+)":\s*"[\^~>=<]*(\d+[\d.]*)')
+
+    for i, line in enumerate(lines):
+        if line.startswith("-") and not line.startswith("---"):
+            old_match = pkg_ver_re.search(line)
+            if old_match and i + 1 < len(lines):
+                next_line = lines[i + 1]
+                if next_line.startswith("+"):
+                    new_match = pkg_ver_re.search(next_line)
+                    if (
+                        new_match
+                        and new_match.group(1) == old_match.group(1)
+                        and old_match.group(2) != new_match.group(2)
+                    ):
+                        changes.append(
+                            {
+                                "name": old_match.group(1),
+                                "oldVersion": old_match.group(2),
+                                "newVersion": new_match.group(2),
+                                "ecosystem": "npm",
+                            }
+                        )
+    return changes
+
+
+def parse_diff(diff_text: str, dep_files: list[str]) -> list[dict[str, str]]:
+    """Parse all dependency changes from the diff."""
+    packages: list[dict[str, str]] = []
+
+    if any("uv.lock" in f for f in dep_files):
+        packages.extend(parse_uv_lock_diff(diff_text))
+    if any("pnpm-lock" in f for f in dep_files):
+        packages.extend(parse_pnpm_lock_diff(diff_text))
+    if any("pyproject.toml" in f for f in dep_files):
+        packages.extend(parse_pyproject_diff(diff_text))
+    if any("package.json" in f or "package-lock.json" in f for f in dep_files):
+        packages.extend(parse_package_json_diff(diff_text))
+
+    seen: set[str] = set()
+    deduped: list[dict[str, str]] = []
+    for pkg in packages:
+        key = f"{pkg['name']}:{pkg['newVersion']}:{pkg['ecosystem']}"
+        if key not in seen:
+            seen.add(key)
+            deduped.append(pkg)
+
+    return deduped
+
+
+def query_osv(packages: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    """Query OSV.dev for vulnerabilities. Returns {key: [advisory,...]}."""
+    results: dict[str, list[dict[str, str]]] = {}
+    queries = [
+        {
+            "version": pkg["newVersion"],
+            "package": {"name": pkg["name"], "ecosystem": pkg["ecosystem"]},
+        }
+        for pkg in packages
+    ]
+
+    for i in range(0, len(queries), OSV_BATCH_SIZE):
+        batch = queries[i : i + OSV_BATCH_SIZE]
+        payload = json.dumps({"queries": batch}).encode("utf-8")
+        req = urllib.request.Request(  # noqa: S310
+            OSV_BATCH_URL,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "dep-check-action/1.0",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=OSV_TIMEOUT) as resp:  # noqa: S310
+                data = json.loads(resp.read())
+                batch_results = data.get("results", [])
+                for j, result in enumerate(batch_results):
+                    vulns = result.get("vulns", [])
+                    if vulns:
+                        pkg = packages[i + j]
+                        key = f"{pkg['name']}:{pkg['newVersion']}:{pkg['ecosystem']}"
+                        results[key] = [
+                            {
+                                "id": v.get("id", ""),
+                                "summary": v.get("summary", "")[:120],
+                            }
+                            for v in vulns[:MAX_ADVISORIES_PER_PKG]
+                        ]
+        except (
+            urllib.error.URLError,
+            json.JSONDecodeError,
+            TimeoutError,
+            OSError,
+        ) as exc:
+            sys.stderr.write(f"::warning::OSV batch query failed: {exc}\n")
+
+    return results
+
+
+def osv_url(advisory_id: str) -> str:
+    """Return the URL for an advisory."""
+    if advisory_id.startswith("GHSA-"):
+        return f"https://github.com/advisories/{advisory_id}"
+    return f"https://osv.dev/vulnerability/{advisory_id}"
+
+
+def format_comment(
+    packages: list[dict[str, str]],
+    vulns: dict[str, list[dict[str, str]]],
+    dep_files: list[str],
+) -> str:
+    """Format the PR comment markdown."""
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    vuln_count = sum(
+        1
+        for pkg in packages
+        if f"{pkg['name']}:{pkg['newVersion']}:{pkg['ecosystem']}" in vulns
+    )
+    clean_count = len(packages) - vuln_count
+    status = "FAIL" if vuln_count > 0 else "PASS"
+
+    lines = [
+        COMMENT_MARKER,
+        "## Dependency Vulnerability Scan",
+        "",
+        f"**Status**: {status}",
+        f"**Scanned**: {now}",
+        f"**Files**: {', '.join(f'`{f}`' for f in dep_files)}",
+        "",
+    ]
+
+    if packages:
+        lines.append("| Package | Version | Ecosystem | Status | Advisory |")
+        lines.append("|---------|---------|-----------|--------|----------|")
+        for pkg in packages:
+            key = f"{pkg['name']}:{pkg['newVersion']}:{pkg['ecosystem']}"
+            if key in vulns:
+                advisories = vulns[key]
+                links = ", ".join(
+                    f"[{a['id']}]({osv_url(a['id'])})" for a in advisories
+                )
+                lines.append(
+                    f"| {pkg['name']} | {pkg['newVersion']} | {pkg['ecosystem']} "
+                    f"| **VULNERABLE** | {links} |"
+                )
+            else:
+                lines.append(
+                    f"| {pkg['name']} | {pkg['newVersion']} | {pkg['ecosystem']} "
+                    "| Clean | \u2014 |"
+                )
+        lines.append("")
+
+    lines.extend(
+        [
+            f"**Summary**: {len(packages)} packages scanned. "
+            f"{clean_count} clean. {vuln_count} vulnerable.",
+            "",
+            "---",
+            "_Re-run with `/recheck`. Auto-scans daily._",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def format_no_deps_comment() -> str:
+    """Format comment when no dependency changes are detected."""
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return "\n".join(
+        [
+            COMMENT_MARKER,
+            "## Dependency Vulnerability Scan",
+            "",
+            "**Status**: PASS",
+            f"**Scanned**: {now}",
+            "",
+            "No dependency file changes detected in this PR.",
+            "",
+            "---",
+            "_Re-run with `/recheck`. Auto-scans daily._",
+        ]
+    )
+
+
+def main() -> int:
+    """Run the dep-check scanner."""
+    parser = argparse.ArgumentParser(description="Dependency vulnerability scanner")
+    parser.add_argument(
+        "--diff", required=True, help="Path to diff file, or '-' for stdin"
+    )
+    parser.add_argument(
+        "--output", default="-", help="Output file for comment markdown"
+    )
+    args = parser.parse_args()
+
+    diff_text = sys.stdin.read() if args.diff == "-" else Path(args.diff).read_text()
+
+    dep_files = detect_dep_files_in_diff(diff_text)
+
+    if not dep_files:
+        _write_output(format_no_deps_comment(), args.output)
+        return 0
+
+    packages = parse_diff(diff_text, dep_files)
+
+    if not packages:
+        _write_output(format_no_deps_comment(), args.output)
+        return 0
+
+    sys.stderr.write(f"Scanning {len(packages)} packages against OSV.dev...\n")
+    vulns = query_osv(packages)
+
+    comment = format_comment(packages, vulns, dep_files)
+    _write_output(comment, args.output)
+
+    if vulns:
+        sys.stderr.write(f"::error::{len(vulns)} vulnerable package(s) found\n")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -126,7 +126,7 @@ jobs:
           # --- .claude/ directory (CRITICAL - known malware vector) ---
           if [ "$CLAUDE_FILE_COUNT" -gt 0 ]; then
             SEVERITY="CRITICAL"
-            FINDINGS="${FINDINGS}### 🚨 CRITICAL: \`.claude/\` Directory Detected\n\n"
+            FINDINGS="${FINDINGS}### CRITICAL: \`.claude/\` Directory Detected\n\n"
             FINDINGS="${FINDINGS}This PR adds or modifies files in \`.claude/\`. "
             FINDINGS="${FINDINGS}This is a **known malware injection vector** (Miasma campaign).\n\n"
             FINDINGS="${FINDINGS}Files containing \`\"command\": \"node .claude/setup.mjs\"\` are **confirmed malware**.\n\n"
@@ -141,17 +141,17 @@ jobs:
             [ "$BRANCH" = "$TRUSTED_SKILL_BRANCH" ] && BRANCH_OK="true"
 
             if [ "$AUTHOR_OK" = "true" ] && [ "$BRANCH_OK" = "true" ]; then
-              FINDINGS="${FINDINGS}### ✅ Skill Sync: Trusted\n\n"
+              FINDINGS="${FINDINGS}### Skill Sync: Trusted\n\n"
               FINDINGS="${FINDINGS}- Author: \`${AUTHOR}\` (trusted bot)\n"
               FINDINGS="${FINDINGS}- Branch: \`${BRANCH}\` (matches sync pattern)\n\n"
             else
               [ "$SEVERITY" = "PASS" ] && SEVERITY="HIGH"
-              FINDINGS="${FINDINGS}### ⚠️ HIGH: Untrusted \`.agents/skills/\` Modification\n\n"
+              FINDINGS="${FINDINGS}### HIGH: Untrusted \`.agents/skills/\` Modification\n\n"
               FINDINGS="${FINDINGS}This PR modifies agent skills but does NOT match the trusted sync pattern:\n"
               FINDINGS="${FINDINGS}- Author: \`${AUTHOR}\` (expected: \`${TRUSTED_BOT}\`)"
-              [ "$AUTHOR_OK" = "true" ] && FINDINGS="${FINDINGS} ✓" || FINDINGS="${FINDINGS} ✗"
+              [ "$AUTHOR_OK" = "true" ] && FINDINGS="${FINDINGS} [PASS]" || FINDINGS="${FINDINGS} [FAIL]"
               FINDINGS="${FINDINGS}\n- Branch: \`${BRANCH}\` (expected: \`${TRUSTED_SKILL_BRANCH}\`)"
-              [ "$BRANCH_OK" = "true" ] && FINDINGS="${FINDINGS} ✓" || FINDINGS="${FINDINGS} ✗"
+              [ "$BRANCH_OK" = "true" ] && FINDINGS="${FINDINGS} [PASS]" || FINDINGS="${FINDINGS} [FAIL]"
               FINDINGS="${FINDINGS}\n\n**Skill changes from untrusted sources require manual security review.**\n\n"
             fi
           fi
@@ -159,7 +159,7 @@ jobs:
           # --- .vscode/ directory (HIGH - IDE config injection) ---
           if [ "$VSCODE_FILE_COUNT" -gt 0 ]; then
             [ "$SEVERITY" = "PASS" ] && SEVERITY="HIGH"
-            FINDINGS="${FINDINGS}### ⚠️ HIGH: \`.vscode/\` Directory Modified\n\n"
+            FINDINGS="${FINDINGS}### HIGH: \`.vscode/\` Directory Modified\n\n"
             FINDINGS="${FINDINGS}This PR modifies IDE configuration files. "
             FINDINGS="${FINDINGS}Malicious extensions or tasks in \`.vscode/\` can execute arbitrary code.\n\n"
             FINDINGS="${FINDINGS}**Review these files carefully:**\n"
@@ -176,7 +176,7 @@ jobs:
                [[ "$BRANCH" != chore/* ]] && \
                [[ "$BRANCH" != fix/* ]]; then
               [ "$SEVERITY" = "PASS" ] && SEVERITY="MEDIUM"
-              FINDINGS="${FINDINGS}### ⚠️ MEDIUM: CI/CD Workflow Modified\n\n"
+              FINDINGS="${FINDINGS}### MEDIUM: CI/CD Workflow Modified\n\n"
               FINDINGS="${FINDINGS}This PR modifies GitHub Actions workflows. "
               FINDINGS="${FINDINGS}Unauthorized pipeline changes can exfiltrate secrets or inject malware into builds.\n\n"
               FINDINGS="${FINDINGS}**Modified workflows:**\n"
@@ -217,7 +217,7 @@ jobs:
 
           {
             echo "${MARKER}"
-            echo "## 🔒 PR Security Check"
+            echo "## PR Security Check"
             echo ""
             echo "**Overall**: ${OVERALL}"
             echo "**Scanned**: ${NOW}"
@@ -291,7 +291,7 @@ jobs:
             NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
             {
               echo "${MARKER}"
-              echo "## 🔒 PR Security Check (Scheduled Re-scan)"
+              echo "## PR Security Check (Scheduled Re-scan)"
               echo ""
               echo "**Scanned**: ${NOW}"
               echo ""

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -38,11 +38,10 @@ jobs:
         env:
           WORKFLOW_REF: ${{ github.job_workflow_sha }}
         run: |
-          # Fetch only the scripts directory from team-devtools
           REF="${WORKFLOW_REF:-main}"
           mkdir -p _scripts/.github/scripts
           gh api "repos/ansible/team-devtools/contents/.github/scripts/dep-check.py?ref=${REF}" \
-            --jq '.content' | base64 -d > _scripts/.github/scripts/dep-check.py
+            --jq '.content' | tr -d '\n' | base64 -d > _scripts/.github/scripts/dep-check.py
           chmod +x _scripts/.github/scripts/dep-check.py
 
       - name: Set up Python

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -108,16 +108,23 @@ jobs:
       - name: Check for malware patterns
         if: github.event_name != 'schedule'
         id: malware
+        env:
+          PR_AUTHOR: ${{ steps.meta.outputs.author }}
+          PR_BRANCH: ${{ steps.meta.outputs.branch }}
+          SKILL_FILE_COUNT: ${{ steps.meta.outputs.skill_files }}
+          CLAUDE_FILE_COUNT: ${{ steps.meta.outputs.claude_files }}
+          VSCODE_FILE_COUNT: ${{ steps.meta.outputs.vscode_files }}
+          WORKFLOW_FILE_COUNT: ${{ steps.meta.outputs.workflow_files }}
         run: |
           FINDINGS=""
           SEVERITY="PASS"
-          AUTHOR="${{ steps.meta.outputs.author }}"
-          BRANCH="${{ steps.meta.outputs.branch }}"
+          AUTHOR="$PR_AUTHOR"
+          BRANCH="$PR_BRANCH"
           TRUSTED_BOT="ansibuddy"
           TRUSTED_SKILL_BRANCH="chore/sync-agent-skills"
 
           # --- .claude/ directory (CRITICAL - known malware vector) ---
-          if [ "${{ steps.meta.outputs.claude_files }}" -gt 0 ]; then
+          if [ "$CLAUDE_FILE_COUNT" -gt 0 ]; then
             SEVERITY="CRITICAL"
             FINDINGS="${FINDINGS}### 🚨 CRITICAL: \`.claude/\` Directory Detected\n\n"
             FINDINGS="${FINDINGS}This PR adds or modifies files in \`.claude/\`. "
@@ -127,7 +134,7 @@ jobs:
           fi
 
           # --- .agents/skills/ (untrusted source check) ---
-          if [ "${{ steps.meta.outputs.skill_files }}" -gt 0 ]; then
+          if [ "$SKILL_FILE_COUNT" -gt 0 ]; then
             AUTHOR_OK="false"
             BRANCH_OK="false"
             [ "$AUTHOR" = "$TRUSTED_BOT" ] && AUTHOR_OK="true"
@@ -150,7 +157,7 @@ jobs:
           fi
 
           # --- .vscode/ directory (HIGH - IDE config injection) ---
-          if [ "${{ steps.meta.outputs.vscode_files }}" -gt 0 ]; then
+          if [ "$VSCODE_FILE_COUNT" -gt 0 ]; then
             [ "$SEVERITY" = "PASS" ] && SEVERITY="HIGH"
             FINDINGS="${FINDINGS}### ⚠️ HIGH: \`.vscode/\` Directory Modified\n\n"
             FINDINGS="${FINDINGS}This PR modifies IDE configuration files. "
@@ -163,7 +170,7 @@ jobs:
           fi
 
           # --- .github/workflows/ (MEDIUM - CI/CD tampering) ---
-          if [ "${{ steps.meta.outputs.workflow_files }}" -gt 0 ]; then
+          if [ "$WORKFLOW_FILE_COUNT" -gt 0 ]; then
             # Trusted sources: the bot or known infra branches
             if [ "$AUTHOR" != "$TRUSTED_BOT" ] && \
                [[ "$BRANCH" != chore/* ]] && \

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -40,6 +40,7 @@ jobs:
           repository: ansible/team-devtools
           ref: ${{ github.job_workflow_sha }}
           sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
           path: _scripts
 
       - name: Set up Python

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -40,8 +40,9 @@ jobs:
         run: |
           REF="${WORKFLOW_REF:-main}"
           mkdir -p _scripts/.github/scripts
-          gh api "repos/ansible/team-devtools/contents/.github/scripts/dep-check.py?ref=${REF}" \
-            --jq '.content' | tr -d '\n' | base64 -d > _scripts/.github/scripts/dep-check.py
+          curl -sSfL \
+            "https://raw.githubusercontent.com/ansible/team-devtools/${REF}/.github/scripts/dep-check.py" \
+            -o _scripts/.github/scripts/dep-check.py
           chmod +x _scripts/.github/scripts/dep-check.py
 
       - name: Set up Python

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -1,0 +1,312 @@
+---
+name: security-check
+
+"on":
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_call:
+    secrets:
+      BOT_PAT:
+        required: false
+
+concurrency:
+  group: security-check-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  security-check:
+    runs-on: ubuntu-24.04
+    if: >
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_call' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+    env:
+      GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ansible/team-devtools
+          sparse-checkout: .github/scripts
+          path: _scripts
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # ─── Resolve PR number ───────────────────────────────────────────
+      - name: Resolve PR number
+        if: github.event_name != 'schedule'
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ─── Gather PR metadata ─────────────────────────────────────────
+      - name: Gather PR metadata
+        if: github.event_name != 'schedule'
+        id: meta
+        run: |
+          PR_NUM="${{ steps.pr.outputs.number }}"
+          REPO="${{ github.repository }}"
+
+          PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPO" \
+            --json author,headRefName,files)
+          echo "author=$(echo "$PR_JSON" | jq -r '.author.login')" >> "$GITHUB_OUTPUT"
+          echo "branch=$(echo "$PR_JSON" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
+
+          # Classify changed files
+          FILES=$(echo "$PR_JSON" | jq -r '.files[].path')
+          echo "$FILES" > /tmp/changed-files.txt
+
+          SKILL_FILES=$(echo "$FILES" | grep -c '^\.agents/skills/' || true)
+          CLAUDE_FILES=$(echo "$FILES" | grep -c '^\.claude/' || true)
+          VSCODE_FILES=$(echo "$FILES" | grep -c '^\.vscode/' || true)
+          WORKFLOW_FILES=$(echo "$FILES" | grep -c '^\.github/workflows/' || true)
+
+          echo "skill_files=${SKILL_FILES}" >> "$GITHUB_OUTPUT"
+          echo "claude_files=${CLAUDE_FILES}" >> "$GITHUB_OUTPUT"
+          echo "vscode_files=${VSCODE_FILES}" >> "$GITHUB_OUTPUT"
+          echo "workflow_files=${WORKFLOW_FILES}" >> "$GITHUB_OUTPUT"
+
+          # Track overall security findings
+          echo "has_security_findings=false" >> "$GITHUB_OUTPUT"
+
+      # ─── CHECK 1: Dependency Vulnerability Scan ──────────────────────
+      - name: Get PR diff
+        if: github.event_name != 'schedule'
+        run: |
+          gh pr diff ${{ steps.pr.outputs.number }} \
+            --repo "${{ github.repository }}" > /tmp/pr.diff || true
+
+      - name: Run dep-check
+        if: github.event_name != 'schedule'
+        id: dep_scan
+        run: |
+          python _scripts/.github/scripts/dep-check.py \
+            --diff /tmp/pr.diff \
+            --output /tmp/dep-comment.md
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      # ─── CHECK 2: Malware Pattern Detection ─────────────────────────
+      - name: Check for malware patterns
+        if: github.event_name != 'schedule'
+        id: malware
+        run: |
+          FINDINGS=""
+          SEVERITY="PASS"
+          AUTHOR="${{ steps.meta.outputs.author }}"
+          BRANCH="${{ steps.meta.outputs.branch }}"
+          TRUSTED_BOT="ansibuddy"
+          TRUSTED_SKILL_BRANCH="chore/sync-agent-skills"
+
+          # --- .claude/ directory (CRITICAL - known malware vector) ---
+          if [ "${{ steps.meta.outputs.claude_files }}" -gt 0 ]; then
+            SEVERITY="CRITICAL"
+            FINDINGS="${FINDINGS}### 🚨 CRITICAL: \`.claude/\` Directory Detected\n\n"
+            FINDINGS="${FINDINGS}This PR adds or modifies files in \`.claude/\`. "
+            FINDINGS="${FINDINGS}This is a **known malware injection vector** (Miasma campaign).\n\n"
+            FINDINGS="${FINDINGS}Files containing \`\"command\": \"node .claude/setup.mjs\"\` are **confirmed malware**.\n\n"
+            FINDINGS="${FINDINGS}**Action required**: Reject this PR immediately unless you can verify the content is safe.\n\n"
+          fi
+
+          # --- .agents/skills/ (untrusted source check) ---
+          if [ "${{ steps.meta.outputs.skill_files }}" -gt 0 ]; then
+            AUTHOR_OK="false"
+            BRANCH_OK="false"
+            [ "$AUTHOR" = "$TRUSTED_BOT" ] && AUTHOR_OK="true"
+            [ "$BRANCH" = "$TRUSTED_SKILL_BRANCH" ] && BRANCH_OK="true"
+
+            if [ "$AUTHOR_OK" = "true" ] && [ "$BRANCH_OK" = "true" ]; then
+              FINDINGS="${FINDINGS}### ✅ Skill Sync: Trusted\n\n"
+              FINDINGS="${FINDINGS}- Author: \`${AUTHOR}\` (trusted bot)\n"
+              FINDINGS="${FINDINGS}- Branch: \`${BRANCH}\` (matches sync pattern)\n\n"
+            else
+              [ "$SEVERITY" = "PASS" ] && SEVERITY="HIGH"
+              FINDINGS="${FINDINGS}### ⚠️ HIGH: Untrusted \`.agents/skills/\` Modification\n\n"
+              FINDINGS="${FINDINGS}This PR modifies agent skills but does NOT match the trusted sync pattern:\n"
+              FINDINGS="${FINDINGS}- Author: \`${AUTHOR}\` (expected: \`${TRUSTED_BOT}\`)"
+              [ "$AUTHOR_OK" = "true" ] && FINDINGS="${FINDINGS} ✓" || FINDINGS="${FINDINGS} ✗"
+              FINDINGS="${FINDINGS}\n- Branch: \`${BRANCH}\` (expected: \`${TRUSTED_SKILL_BRANCH}\`)"
+              [ "$BRANCH_OK" = "true" ] && FINDINGS="${FINDINGS} ✓" || FINDINGS="${FINDINGS} ✗"
+              FINDINGS="${FINDINGS}\n\n**Skill changes from untrusted sources require manual security review.**\n\n"
+            fi
+          fi
+
+          # --- .vscode/ directory (HIGH - IDE config injection) ---
+          if [ "${{ steps.meta.outputs.vscode_files }}" -gt 0 ]; then
+            [ "$SEVERITY" = "PASS" ] && SEVERITY="HIGH"
+            FINDINGS="${FINDINGS}### ⚠️ HIGH: \`.vscode/\` Directory Modified\n\n"
+            FINDINGS="${FINDINGS}This PR modifies IDE configuration files. "
+            FINDINGS="${FINDINGS}Malicious extensions or tasks in \`.vscode/\` can execute arbitrary code.\n\n"
+            FINDINGS="${FINDINGS}**Review these files carefully:**\n"
+            grep '\.vscode/' /tmp/changed-files.txt | while read -r f; do
+              FINDINGS="${FINDINGS}- \`${f}\`\n"
+            done
+            FINDINGS="${FINDINGS}\n"
+          fi
+
+          # --- .github/workflows/ (MEDIUM - CI/CD tampering) ---
+          if [ "${{ steps.meta.outputs.workflow_files }}" -gt 0 ]; then
+            # Trusted sources: the bot or known infra branches
+            if [ "$AUTHOR" != "$TRUSTED_BOT" ] && \
+               [[ "$BRANCH" != chore/* ]] && \
+               [[ "$BRANCH" != fix/* ]]; then
+              [ "$SEVERITY" = "PASS" ] && SEVERITY="MEDIUM"
+              FINDINGS="${FINDINGS}### ⚠️ MEDIUM: CI/CD Workflow Modified\n\n"
+              FINDINGS="${FINDINGS}This PR modifies GitHub Actions workflows. "
+              FINDINGS="${FINDINGS}Unauthorized pipeline changes can exfiltrate secrets or inject malware into builds.\n\n"
+              FINDINGS="${FINDINGS}**Modified workflows:**\n"
+              grep '\.github/workflows/' /tmp/changed-files.txt | while read -r f; do
+                FINDINGS="${FINDINGS}- \`${f}\`\n"
+              done
+              FINDINGS="${FINDINGS}\n**Ensure this change is intentional and reviewed by a maintainer.**\n\n"
+            fi
+          fi
+
+          # Write outputs
+          echo "severity=${SEVERITY}" >> "$GITHUB_OUTPUT"
+          if [ -n "$FINDINGS" ]; then
+            # Use a file to avoid escaping issues
+            printf '%b' "$FINDINGS" > /tmp/malware-findings.md
+          else
+            echo "" > /tmp/malware-findings.md
+          fi
+
+      # ─── Compose and Post Comment ───────────────────────────────────
+      - name: Compose security comment
+        if: github.event_name != 'schedule'
+        id: compose
+        run: |
+          MARKER="<!-- security-check-result -->"
+          NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          SEVERITY="${{ steps.malware.outputs.severity }}"
+          DEP_STATUS="PASS"
+          [ "${{ steps.dep_scan.outcome }}" = "failure" ] && DEP_STATUS="FAIL"
+
+          # Determine overall status
+          OVERALL="PASS"
+          if [ "$SEVERITY" = "CRITICAL" ] || [ "$DEP_STATUS" = "FAIL" ]; then
+            OVERALL="FAIL"
+          elif [ "$SEVERITY" = "HIGH" ] || [ "$SEVERITY" = "MEDIUM" ]; then
+            OVERALL="WARNING"
+          fi
+
+          {
+            echo "${MARKER}"
+            echo "## 🔒 PR Security Check"
+            echo ""
+            echo "**Overall**: ${OVERALL}"
+            echo "**Scanned**: ${NOW}"
+            echo ""
+
+            # Malware/injection findings
+            if [ -s /tmp/malware-findings.md ]; then
+              cat /tmp/malware-findings.md
+              echo ""
+            fi
+
+            # Dependency scan results
+            if [ -f /tmp/dep-comment.md ]; then
+              # Strip the marker from dep-comment (we have our own)
+              sed '1d' /tmp/dep-comment.md
+              echo ""
+            fi
+
+            echo "---"
+            echo "_Re-run with \`/recheck\`. Dependency scan runs daily._"
+          } > /tmp/security-comment.md
+
+          echo "overall=${OVERALL}" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: github.event_name != 'schedule'
+        run: |
+          PR_NUM="${{ steps.pr.outputs.number }}"
+          REPO="${{ github.repository }}"
+          MARKER="<!-- security-check-result -->"
+
+          COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+            2>/dev/null | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -F "body=@/tmp/security-comment.md"
+          else
+            gh pr comment "$PR_NUM" --repo "$REPO" \
+              --body-file /tmp/security-comment.md
+          fi
+
+      - name: Fail on critical findings
+        if: >
+          github.event_name != 'schedule' &&
+          (steps.compose.outputs.overall == 'FAIL')
+        run: |
+          echo "::error::Security check failed — see PR comment for details"
+          exit 1
+
+      # ─── Scheduled: re-scan all open PRs ────────────────────────────
+      - name: Re-scan open PRs (scheduled)
+        if: github.event_name == 'schedule'
+        run: |
+          REPO="${{ github.repository }}"
+          MARKER="<!-- security-check-result -->"
+
+          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open \
+            --json number --jq '.[].number')
+
+          for PR_NUM in $PR_NUMBERS; do
+            echo "::group::Scanning PR #${PR_NUM}"
+
+            gh pr diff "$PR_NUM" --repo "$REPO" > /tmp/pr.diff 2>/dev/null || continue
+
+            python _scripts/.github/scripts/dep-check.py \
+              --diff /tmp/pr.diff \
+              --output /tmp/dep-comment.md || true
+
+            NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            {
+              echo "${MARKER}"
+              echo "## 🔒 PR Security Check (Scheduled Re-scan)"
+              echo ""
+              echo "**Scanned**: ${NOW}"
+              echo ""
+              if [ -f /tmp/dep-comment.md ]; then
+                sed '1d' /tmp/dep-comment.md
+              fi
+              echo ""
+              echo "---"
+              echo "_Re-run with \`/recheck\`. Dependency scan runs daily._"
+            } > /tmp/security-comment.md
+
+            COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" \
+              --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+              2>/dev/null | head -1)
+
+            if [ -n "$COMMENT_ID" ]; then
+              gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+                -X PATCH -F "body=@/tmp/security-comment.md"
+            else
+              gh pr comment "$PR_NUM" --repo "$REPO" \
+                --body-file /tmp/security-comment.md
+            fi
+
+            echo "::endgroup::"
+          done

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ansible/team-devtools
+          ref: ${{ github.job_workflow_sha }}
           sparse-checkout: .github/scripts
           path: _scripts
 

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -35,15 +35,13 @@ jobs:
       GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout workflow scripts
-        env:
-          WORKFLOW_REF: ${{ github.job_workflow_sha }}
-        run: |
-          REF="${WORKFLOW_REF:-main}"
-          mkdir -p _scripts/.github/scripts
-          curl -sSfL \
-            "https://raw.githubusercontent.com/ansible/team-devtools/${REF}/.github/scripts/dep-check.py" \
-            -o _scripts/.github/scripts/dep-check.py
-          chmod +x _scripts/.github/scripts/dep-check.py
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ansible/team-devtools
+          sparse-checkout: |
+            .github/scripts/
+          sparse-checkout-cone-mode: false
+          path: _scripts
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -35,13 +35,15 @@ jobs:
       GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout workflow scripts
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: ansible/team-devtools
-          ref: ${{ github.job_workflow_sha }}
-          sparse-checkout: .github/scripts
-          sparse-checkout-cone-mode: false
-          path: _scripts
+        env:
+          WORKFLOW_REF: ${{ github.job_workflow_sha }}
+        run: |
+          # Fetch only the scripts directory from team-devtools
+          REF="${WORKFLOW_REF:-main}"
+          mkdir -p _scripts/.github/scripts
+          gh api "repos/ansible/team-devtools/contents/.github/scripts/dep-check.py?ref=${REF}" \
+            --jq '.content' | base64 -d > _scripts/.github/scripts/dep-check.py
+          chmod +x _scripts/.github/scripts/dep-check.py
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,10 @@ lines-after-imports = 2  # Ensures consistency for cases when there's variable v
   "INP001",  # implicit namespace package (standalone scripts, not a library)
   "T201",  # print statements (CLI progress output)
 ]
+".github/scripts/*" = [
+  "INP001",  # implicit namespace package (standalone scripts, not a library)
+  "T201",  # print statements (CLI progress output)
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/test/test_dep_check.py
+++ b/test/test_dep_check.py
@@ -1,0 +1,266 @@
+"""Tests for the dep-check security script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / ".github" / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "dep_check", SCRIPTS_DIR / "dep-check.py"
+)
+assert _spec
+assert _spec.loader
+dep_check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dep_check)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+UV_LOCK_DIFF = """\
+diff --git a/uv.lock b/uv.lock
+index abc1234..def5678 100644
+--- a/uv.lock
++++ b/uv.lock
+@@ -10,7 +10,7 @@
+
+ [[package]]
+ name = "requests"
+-version = "2.31.0"
++version = "2.32.0"
+ source = { registry = "https://pypi.org/simple" }
+
+ [[package]]
+ name = "cryptography"
+-version = "41.0.0"
++version = "42.0.0"
+ source = { registry = "https://pypi.org/simple" }
+"""
+
+PNPM_LOCK_DIFF = """\
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index abc1234..def5678 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -50,7 +50,7 @@
+    packages:
+        lodash:
+-            version: 4.17.20
++            version: 4.17.21
+"""
+
+PACKAGE_JSON_DIFF = """\
+diff --git a/package.json b/package.json
+index abc1234..def5678 100644
+--- a/package.json
++++ b/package.json
+@@ -5,7 +5,7 @@
+   "dependencies": {
+-    "express": "^4.18.1"
++    "express": "^4.19.0"
+   }
+"""
+
+PYPROJECT_DIFF = """\
+diff --git a/pyproject.toml b/pyproject.toml
+index abc1234..def5678 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -10,7 +10,7 @@
+ dependencies = [
+-    "ansible-core>=2.15.0",
++    "ansible-core>=2.16.0",
+ ]
+"""
+
+NO_DEP_DIFF = """\
+diff --git a/src/main.py b/src/main.py
+index abc1234..def5678 100644
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,3 +1,4 @@
++import os
+ import sys
+"""
+
+
+# ─── Test is_dep_file ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    (
+        ("uv.lock", True),
+        ("pyproject.toml", True),
+        ("package.json", True),
+        ("pnpm-lock.yaml", True),
+        ("requirements.txt", True),
+        ("requirements-dev.txt", True),
+        ("Pipfile.lock", True),
+        ("src/main.py", False),
+        ("README.md", False),
+        (".github/workflows/ci.yml", False),
+        ("sub/dir/pnpm-lock.yaml", True),
+    ),
+)
+def test_is_dep_file(path: str, *, expected: bool) -> None:
+    """Verify dependency file detection."""
+    assert dep_check.is_dep_file(path) is expected
+
+
+# ─── Test detect_dep_files_in_diff ─────────────────────────────────────────
+
+
+def test_detect_dep_files_in_diff_uv_lock() -> None:
+    """Detect uv.lock in a diff."""
+    files = dep_check.detect_dep_files_in_diff(UV_LOCK_DIFF)
+    assert "uv.lock" in files
+
+
+def test_detect_dep_files_in_diff_no_deps() -> None:
+    """Return empty list when no dep files are changed."""
+    files = dep_check.detect_dep_files_in_diff(NO_DEP_DIFF)
+    assert files == []
+
+
+# ─── Test parsers ──────────────────────────────────────────────────────────
+
+
+EXPECTED_UV_LOCK_CHANGES = 2
+
+
+def test_parse_uv_lock_diff() -> None:
+    """Parse version changes from uv.lock diff."""
+    changes = dep_check.parse_uv_lock_diff(UV_LOCK_DIFF)
+    assert len(changes) == EXPECTED_UV_LOCK_CHANGES
+    names = {c["name"] for c in changes}
+    assert "requests" in names
+    assert "cryptography" in names
+    req = next(c for c in changes if c["name"] == "requests")
+    assert req["oldVersion"] == "2.31.0"
+    assert req["newVersion"] == "2.32.0"
+    assert req["ecosystem"] == "PyPI"
+
+
+def test_parse_pnpm_lock_diff() -> None:
+    """Parse version changes from pnpm-lock.yaml diff."""
+    changes = dep_check.parse_pnpm_lock_diff(PNPM_LOCK_DIFF)
+    assert len(changes) == 1
+    assert changes[0]["name"] == "lodash"
+    assert changes[0]["oldVersion"] == "4.17.20"
+    assert changes[0]["newVersion"] == "4.17.21"
+    assert changes[0]["ecosystem"] == "npm"
+
+
+def test_parse_package_json_diff() -> None:
+    """Parse version changes from package.json diff."""
+    changes = dep_check.parse_package_json_diff(PACKAGE_JSON_DIFF)
+    assert len(changes) == 1
+    assert changes[0]["name"] == "express"
+    assert changes[0]["oldVersion"] == "4.18.1"
+    assert changes[0]["newVersion"] == "4.19.0"
+    assert changes[0]["ecosystem"] == "npm"
+
+
+def test_parse_pyproject_diff() -> None:
+    """Parse version changes from pyproject.toml diff."""
+    changes = dep_check.parse_pyproject_diff(PYPROJECT_DIFF)
+    assert len(changes) == 1
+    assert changes[0]["name"] == "ansible-core"
+    assert changes[0]["oldVersion"] == "2.15.0"
+    assert changes[0]["newVersion"] == "2.16.0"
+    assert changes[0]["ecosystem"] == "PyPI"
+
+
+# ─── Test parse_diff integration ──────────────────────────────────────────
+
+
+def test_parse_diff_deduplicates() -> None:
+    """Verify deduplication in parse_diff."""
+    double_diff = UV_LOCK_DIFF + UV_LOCK_DIFF
+    dep_files = dep_check.detect_dep_files_in_diff(double_diff)
+    packages = dep_check.parse_diff(double_diff, dep_files)
+    names = [p["name"] for p in packages]
+    assert names.count("requests") == 1
+
+
+# ─── Test OSV query ───────────────────────────────────────────────────────
+
+
+def test_query_osv_handles_empty_list() -> None:
+    """Empty package list should return empty results."""
+    results = dep_check.query_osv([])
+    assert results == {}
+
+
+def test_query_osv_handles_network_error() -> None:
+    """Network errors should be handled gracefully."""
+    import urllib.error
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        packages = [{"name": "foo", "newVersion": "1.0", "ecosystem": "PyPI"}]
+        results = dep_check.query_osv(packages)
+        assert results == {}
+
+
+# ─── Test comment formatting ──────────────────────────────────────────────
+
+
+def test_format_comment_clean() -> None:
+    """Format comment with no vulnerabilities."""
+    packages = [{"name": "requests", "newVersion": "2.32.0", "ecosystem": "PyPI"}]
+    vulns: dict[str, list[dict[str, str]]] = {}
+    comment = dep_check.format_comment(packages, vulns, ["uv.lock"])
+    assert "PASS" in comment
+    assert "requests" in comment
+    assert "Clean" in comment
+    assert dep_check.COMMENT_MARKER in comment
+
+
+def test_format_comment_vulnerable() -> None:
+    """Format comment with vulnerabilities."""
+    packages = [{"name": "cryptography", "newVersion": "42.0.0", "ecosystem": "PyPI"}]
+    vulns = {
+        "cryptography:42.0.0:PyPI": [
+            {"id": "GHSA-xxxx-yyyy-zzzz", "summary": "Test vuln"},
+        ],
+    }
+    comment = dep_check.format_comment(packages, vulns, ["uv.lock"])
+    assert "FAIL" in comment
+    assert "**VULNERABLE**" in comment
+    assert "GHSA-xxxx-yyyy-zzzz" in comment
+    assert "https://github.com/advisories/GHSA-xxxx-yyyy-zzzz" in comment
+
+
+def test_format_no_deps_comment() -> None:
+    """Format comment when no deps changed."""
+    comment = dep_check.format_no_deps_comment()
+    assert "PASS" in comment
+    assert "No dependency file changes" in comment
+    assert dep_check.COMMENT_MARKER in comment
+
+
+# ─── Test osv_url ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("advisory_id", "expected_prefix"),
+    (
+        ("GHSA-xxxx-yyyy-zzzz", "https://github.com/advisories/"),
+        ("PYSEC-2024-001", "https://osv.dev/vulnerability/"),
+        ("CVE-2024-12345", "https://osv.dev/vulnerability/"),
+    ),
+)
+def test_osv_url(advisory_id: str, expected_prefix: str) -> None:
+    """Verify advisory URL generation."""
+    url = dep_check.osv_url(advisory_id)
+    assert url.startswith(expected_prefix)
+    assert advisory_id in url


### PR DESCRIPTION
## Summary

- Adds a single unified `security-check.yml` reusable workflow that performs all PR security checks
- Adds `.github/scripts/dep-check.py` Python script for dependency diff parsing and OSV batch queries
- Adds `test/test_dep_check.py` with 26 unit tests for the script
- Adds per-file ruff ignore for `.github/scripts/`

## Security Checks Performed

| # | Check | Severity | Vector |
|---|-------|----------|--------|
| 1 | **Dependency vulnerability scan** — parses dep file diffs, queries OSV.dev | FAIL | Known CVEs in dependencies |
| 2 | **`.claude/` directory detection** — immediate block | CRITICAL | Miasma malware campaign |
| 3 | **`.agents/skills/` injection** — untrusted skill modifications | HIGH | Agent skill poisoning |
| 4 | **`.vscode/` IDE config injection** — flags malicious extensions/tasks | HIGH | IDE config injection |
| 5 | **CI/CD workflow tampering** — workflow changes from untrusted sources | MEDIUM | Pipeline secret exfiltration |

## Workflow Details

**Triggers**: `pull_request_target`, `issue_comment` (`/recheck`), daily `schedule`, `workflow_call`

**Behavior**:
- Posts/updates a single unified PR comment with all findings (uses HTML comment marker — no duplicates)
- Fails the check on CRITICAL findings (`.claude/`) or vulnerable dependencies
- Warns on HIGH/MEDIUM findings (untrusted skills, `.vscode/`, workflow changes)
- Scheduled daily re-scan of all open PRs catches newly disclosed vulnerabilities

## Downstream Consumption

Each repo adds a caller workflow:

```yaml
name: security-check
on:
  pull_request_target:
    types: [opened, synchronize, reopened]
  issue_comment:
    types: [created]
jobs:
  security-check:
    uses: ansible/team-devtools/.github/workflows/security-check.yml@main
    secrets: inherit
```

## Integration Testing

Tested end-to-end on `ansible/ansible-lint` PR #5061 (Renovate security update):
- Workflow ran successfully as a GitHub check
- Posted correct PR comment with scan results (PASS, 1 package scanned)
- `/recheck` comment trigger works
- Test workflow was reverted from ansible-lint main after verification (commit `9e21e07e`)

## Related

Ref: ACA-6408

## Test plan

- [x] Tested dep-check.py locally against real PR diffs (clean + vulnerable)
- [x] 26 unit tests passing (parsers, formatting, error handling)
- [x] Ruff check + format passes
- [x] CodeQL passes (no injection warnings)
- [x] CI passes on this PR
- [x] Integration test on ansible-lint PR #5061 — workflow ran, posted comment, showed as check
- [x] Test workflow reverted from ansible-lint after verification

## Attribution

Human-led, AI-assisted (Cursor Agent).