### PR TITLE
fix: make failure to auto-merge a warning

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -93,7 +93,7 @@ jobs:
           )
         run: |
           set -e
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL" || echo "::warning::Failed to auto-merge PR $PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ env.BOT_PAT }}


### PR DESCRIPTION
As `ack` workflow is also required for merge in most repos, ensure
that failure to set auto-merge flag is only generating a warning so
we degrade gracefuly when tokens are expired or missing.
