### PR TITLE
feat(skills): upgrade pr-new and pr-review with APME improvements

### DIFF
--- a/.agents/skills/pr-contributor-review/SKILL.md
+++ b/.agents/skills/pr-contributor-review/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "<PR number or URL>"
 user-invocable: true
 metadata:
   author: Ansible DevTools Team
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Review Contributor PR
@@ -18,6 +18,11 @@ This skill defines how to review and assist with a **contributor's** pull
 request (someone else's PR, e.g. from a fork or another branch). Use it when
 you are helping make a contributor PR merge-ready, not when submitting your
 own PR (use `pr-new` for that).
+
+When performing the actual code review (evaluating correctness, safety,
+consistency), apply the evaluation principles documented in the **`pr-review`**
+skill under "How automated reviewers evaluate code". Those principles are the
+standard lens for all code review in devtools projects.
 
 ## Goals
 

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -3,14 +3,15 @@ name: pr-new
 description: >
   Prepare and submit a pull request. Syncs with upstream,
   creates a feature branch, runs quality gates (tox -e lint, tox -e py),
-  updates documentation as needed, commits with conventional commits,
-  then creates the PR via gh. Use when the user asks to submit, create, or open
-  a pull request, or says "submit PR", "open PR", "create PR", "new PR".
+  self-reviews the diff, updates documentation as needed, commits with
+  conventional commits, then creates the PR via gh. Use when the user asks
+  to submit, create, or open a pull request, or says "submit PR", "open PR",
+  "create PR", "new PR".
 argument-hint: "[branch-name] [--title 'PR title']"
 user-invocable: true
 metadata:
   author: Ansible DevTools Team
-  version: 1.0.0
+  version: 2.0.0
 ---
 
 # PR New
@@ -43,7 +44,174 @@ If the branch has pre-existing violations (e.g., from an old base), rebase onto 
 Do **not** run `ruff`, `mypy`, `prek`, or `pytest` directly — always use tox.
 See the `/tox` skill for the full environment reference.
 
-### Step 3: Update documentation
+### Step 3: Self-review the diff
+
+**This step is mandatory.** Do not skip it. Do not combine it with
+Step 2. After quality gates pass, review the **full PR diff** — all commits
+since the branch diverged from the base branch:
+
+```bash
+git diff upstream/main...HEAD
+```
+
+Read every changed line against these questions. For each question,
+name at least one specific file and line you verified. If you cannot,
+you haven't actually reviewed the diff.
+
+**Context rule.** The diff alone is not sufficient for Q1, Q4, and Q7.
+Before evaluating those questions, **read the full function, class, or
+module** surrounding each changed hunk — not just the hunk itself.
+
+1. **Does every statement mean what it says?** Check every type
+   annotation, return value, error code, version range, log level,
+   comment, and docstring. If the code declares it, the runtime must
+   honor it on every path.
+
+2. **Does this expose more than it should?** Check every log call,
+   error message, and user-facing string. Does it contain user content,
+   credentials, or internal state? Also check capability grants:
+   permission scopes, container capabilities, CORS origins. Each must
+   grant the minimum necessary.
+
+3. **Would a caller be surprised?** Read every public function from
+   the caller's perspective. Can it return a value the type doesn't
+   cover? Does it mutate an argument the caller owns? Does it throw
+   where the signature implies it won't? Does it have side effects
+   (logging, I/O, global state) that its name or signature doesn't
+   advertise?
+
+4. **Is everything still true after this change?** Diff comments and
+   docstrings against the code they describe. Did you rename something
+   but leave the old name in prose? Did you change behavior but leave
+   an old description? Check `AGENTS.md`, `README.md`, and `docs/`
+   for stale references.
+
+5. **Are dependencies and versions pinned to intent?** Check every
+   version range, action tag, and base image. Does each one express
+   what you actually mean — not tighter, not looser?
+
+6. **Is there dead weight?** Check for unused imports, unreachable
+   branches, written-but-never-read variables, parameters accepted
+   but ignored. Also flag paid-for-but-wasteful work: parsing the
+   same data twice, `list.pop(0)` when a `deque` would be O(1),
+   nested scans that are O(N²) when a lookup map would be O(N).
+
+7. **Is this internally consistent?** Within each module: do all code
+   paths use the same patterns? Are exports named consistently? Across
+   the repo: do similar files follow the same structure? Do GitHub
+   Actions use pinned SHAs consistently?
+
+8. **Would a constructed scenario break this?** For each public
+   function, construct one realistic failure case: an edge-case input,
+   an empty-but-not-falsy value, a timeout, a concurrent access. Trace
+   it through the code path. If it fails silently or violates the
+   declared type, that's a finding.
+
+9. **Do inherited contracts hold?** When implementing a Protocol or
+   extending a base class, check that the subclass honors the full
+   runtime contract — not just the compiler-required members but
+   expected behaviors and invariants.
+
+Only proceed to Step 3b after completing this review.
+
+### Step 3b: Rule of Five (cold multi-agent review)
+
+**This step is mandatory.** Step 3 catches many issues but suffers from
+confirmation bias because the reviewing agent wrote the code. The Rule
+of Five mitigates this with five independent analysis passes, each
+constrained to a single evaluative lens.
+
+Launch five parallel agents (or evaluate sequentially), each receiving
+the full diff (`git diff upstream/main...HEAD`) and a single lens:
+
+#### Pass 1 — Correctness and safety
+
+```text
+You are reviewer 1 of 5 evaluating a PR diff. Your ONLY lens is
+correctness and safety. Ignore style, naming, and architecture.
+
+Look for:
+- Logic errors, off-by-one, wrong operator, inverted condition
+- Unhandled None/empty/error paths that reach callers
+- Type mismatches between declaration and runtime
+- Race conditions, resource leaks, missing cleanup
+- Security: injection, path traversal, SSRF, credential exposure
+```
+
+#### Pass 2 — Fresh eyes (what a reviewer would flag)
+
+```text
+You are reviewer 2 of 5 evaluating a PR diff. Your ONLY lens is
+"what would a human reviewer flag in code review?"
+
+Look for:
+- Misleading names, unclear intent, magic values without context
+- Public API changes that break callers without migration
+- Missing or inaccurate docstrings/comments vs actual behavior
+- Test gaps for behaviors the code/docs claim
+- Dead branches, unused params, wasteful computation
+- Dependencies pinned to intent (not tighter, not looser)
+- GitHub Actions pinned to SHA (not mutable tag)
+```
+
+#### Pass 3 — Right Thing / product fitness
+
+```text
+You are reviewer 3 of 5 evaluating a PR diff. Your ONLY lens is
+whether we are doing the Right Thing.
+
+Look for:
+- Does this actually solve the stated goal, or is it a half-measure?
+- Are lifecycle triggers complete, or will users lose state unexpectedly?
+- Is the API shape honest for the UX story?
+- Any invariant violations (tox-only, conventional commits, etc.)?
+- Do implementations honor full runtime contracts, not just type stubs?
+```
+
+#### Pass 4 — System architecture
+
+```text
+You are reviewer 4 of 5 evaluating a PR diff. Your ONLY lens is
+system architecture.
+
+Look for:
+- Dependency direction violations (circular imports, wrong layers)
+- Where state lives and failure modes (concurrency, restart, partial)
+- Scaling: algorithmic cost, parameter limits, fan-out under load
+- Migration/backfill for existing deployments or data
+- Cross-artifact parity (workflow ↔ script, config ↔ code)
+```
+
+#### Pass 5 — Adversarial / exposure / simplify
+
+```text
+You are reviewer 5 of 5 evaluating a PR diff. Be creatively adversarial.
+
+Look for:
+- Weird but realistic scenarios that corrupt state or bypass checks
+- Information exposure: logs, errors, persisted data with credentials
+  or internal paths
+- If you deleted 50% of this design, what still ships the goal?
+- Simplify/kill recommendations
+
+Return: (1) adversarial findings, (2) simplify recommendations,
+(3) verdict: merge-ready or what must change first?
+```
+
+#### Aggregate, act, converge
+
+After all passes return:
+
+1. **Deduplicate** findings and build a table: finding → which passes → severity.
+2. **Ship-blockers** = any finding raised by **≥2 passes**, plus any single-pass
+   **critical** finding (data corruption, security exposure, invariant violation).
+3. **Act on ship-blockers.** Fix code, re-run `tox -e lint` and `tox -e py`.
+4. **Re-run Rule of Five** after substantive fixes until no new ship-blockers.
+5. Document dismissed findings with a clear technical justification.
+
+Do not proceed to Step 4 until convergence.
+
+### Step 4: Update documentation
 
 Check whether your changes affect areas covered by existing docs. Update any that apply:
 
@@ -54,7 +222,7 @@ Check whether your changes affect areas covered by existing docs. Update any tha
 | `CONTRIBUTING.md` | Contribution workflow or policy changes |
 | `AGENTS.md` | Agent behavior, skill references, static check config |
 
-### Step 4: Commit with conventional commits
+### Step 5: Commit with conventional commits
 
 Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
 
@@ -95,7 +263,7 @@ Include ticket references in the commit footer:
 - `Related: AAP-123` for JIRA tickets
 - Do not use URLs — use plain text references
 
-### Step 5: Push and create the pull request
+### Step 6: Push and create the pull request
 
 ```bash
 git push -u origin HEAD
@@ -152,6 +320,7 @@ The Summary, Changes, and Test plan sections must stay current with all commits 
 
 ### Responding to review feedback
 
-After pushing the PR, reviewers (human or Copilot) may leave comments. Follow
-the **`pr-review`** skill for the full procedure: checking CI status, replying
-to comments, resolving threads, and re-checking for new Copilot reviews.
+After pushing the PR, reviewers (human, Copilot, or CodeRabbit) may leave
+comments. Follow the **`pr-review`** skill for the full procedure: checking CI
+status, replying to comments, resolving threads, and re-checking for new
+automated reviews.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: pr-review
 description: >
-  Use when handling pull request reviews, including automated (Copilot) and
-  human reviewer feedback. Use when responding to PR comments, resolving
-  review threads, or updating PRs after review.
+  Guide for handling pull request reviews, including automated (Copilot,
+  CodeRabbit) and human reviewer feedback. Use when responding to PR comments,
+  resolving review threads, or updating PRs after review.
 argument-hint: "<PR number>"
 user-invocable: true
 metadata:
   author: Ansible DevTools Team
-  version: 1.0.0
+  version: 2.0.0
 ---
 
 # PR Review
 
-This skill defines how to handle PR review feedback in this project.
+This skill defines how to handle PR review feedback in Ansible DevTools projects.
 
 ## Responding to review comments
 
@@ -24,19 +24,23 @@ disputed threads block merge.
 
 ### Rules
 
-- Address ALL review comments before requesting re-review. Do not leave
+* Address ALL review comments before requesting re-review. Do not leave
   comments unanswered.
-- Every comment requires a **closing reply**. When the feedback is addressed
-  or accepted, also **resolve the thread** via the GitHub UI or API. When
+
+* Every comment requires a **closing reply**. When the feedback is addressed
+  or accepted, also **resolve the thread** via the GitHub API. When
   disputing or flagging a false positive, leave the thread unresolved for
   human escalation.
-- Reply to each comment with a **brief explanation of how it was resolved** and
+
+* Reply to each comment with a **brief explanation of how it was resolved** and
   the commit hash (e.g., "Removed the unused imports so Ruff F401 passes.
   Fixed in abc1234."). Do not reply with only the SHA; explain the fix.
-- If a comment is a false positive or you disagree, reply with a clear
+
+* If a comment is a false positive or you disagree, reply with a clear
   technical explanation. Do not resolve the thread. This will require human
   intervention. Do not dismiss without justification.
-- After pushing fixes, update the PR description to reflect the expanded scope
+
+* After pushing fixes, update the PR description to reflect the expanded scope
   (per the pr-new skill).
 
 ### Deferred work MUST be tracked
@@ -72,9 +76,117 @@ EOF
 )"
 ```
 
-## Copilot review patterns
+## Automated reviews as agent learning opportunities
 
-Copilot automated reviews surface recurring categories. Address these
+Every automated reviewer comment (Copilot, CodeRabbit) on an agent-authored
+PR is a defect in our own review process. These tools apply the same
+principles every time — if one found something, the agent's pre-submit
+self-review (see the `pr-new` skill, Step 3 + Step 3b Rule of Five)
+should have found it first. Without tightening that loop, we will never
+ship a PR without comments.
+
+After fixing each automated finding, ask: _which principle from the
+pr-new self-review (Step 3 questions or Rule of Five pass 1–5) should
+have caught this?_ If one exists but didn't trigger, the principle needs
+to be clearer or the agent didn't apply it. If no principle covers it,
+strengthen the matching Rule of Five lens (or Step 3 question) — frame
+it as a general evaluation criterion, not a specific instance. Adding
+"don't do X" only prevents X; strengthening a principle prevents the
+entire class of issues X belongs to.
+
+## How automated reviewers evaluate code
+
+Automated reviewers (Copilot, CodeRabbit) succeed because they apply a
+small number of universal evaluation criteria to every line of the diff.
+Understanding these criteria lets the agent anticipate findings rather
+than react to them.
+
+**Semantic truthfulness.** Every declaration is read as a contract.
+The reviewer checks whether types, return values, error codes, version
+ranges, log levels, comments, and docstrings accurately describe what
+the code actually does. Any gap — a comment that says "all" when the
+code means "some", a return type that promises `T` but can produce
+`None`, a docstring that lists parameters the function no longer
+accepts — gets flagged.
+
+**Information exposure.** The reviewer asks "should this data be visible
+here?" for every piece of information that escapes internal scope:
+logged data, error messages, API responses, documentation examples.
+User content in info-level logs, credentials on CLI examples, internal
+paths in error messages — all get flagged because the reviewer assumes
+the minimum-exposure principle.
+
+**Caller safety.** The reviewer reads every public interface from the
+caller's perspective and asks "could this surprise me?" Nullable
+returns not reflected in the type, missing null guards on
+platform-provided arguments, unsafe casts, optional fields typed as
+required, hidden side effects (logging, I/O, global state) that the
+name or signature doesn't advertise — all get flagged because the
+reviewer assumes callers trust the type signature and expect no
+undisclosed behavior.
+
+**Drift between prose and code.** Any time a comment, docstring,
+README, or inline annotation co-exists with the code it describes,
+the reviewer checks whether the prose is still true after the diff.
+Renamed functions with old docstrings, changed triggers with old
+workflow descriptions, removed features with lingering references —
+all flagged.
+
+**Supply-chain mutability.** References to external resources (action
+tags, dependency versions, base images) that can change without
+review get flagged. The reviewer assumes that anything not pinned to
+a specific immutable identifier is a vector for silent behavior change.
+
+**Internal consistency.** Every module's exports, code paths, and
+naming conventions are checked against each other. If nine code paths
+use a registry lookup but the tenth hardcodes a value, or if one
+export capitalizes differently from its siblings, the reviewer flags
+the deviation because inconsistency signals copy-paste drift or an
+unfinished refactor.
+
+**Adversarial input tracing.** The reviewer constructs edge-case
+scenarios for public functions: what happens with an empty-but-not-falsy
+value, a field combination after partial deletion, a response that
+satisfies the HTTP status check but lacks expected fields? If the traced
+path fails silently, sends a vacuous request, or produces a return value
+that violates the declared type, the reviewer flags it.
+
+**Inherited contract completeness.** When the diff extends a class or
+implements a Protocol, the reviewer checks that the subclass honors the
+full runtime contract — not just the compiler-required members but
+expected behaviors and invariants.
+
+**Dead weight.** Unused imports, unreachable branches, written-but-never-
+read variables, parameters accepted but ignored — anything the code
+pays for but doesn't use. The reviewer assumes dead code obscures intent
+and may mask bugs.
+
+### DevTools-specific patterns
+
+These are known project-specific applications of the principles above.
+They serve as a quick reference, not an exhaustive list — the principles
+above should catch novel issues these don't cover.
+
+- **tox-only invocation**: never invoke `ruff`, `mypy`, `pytest`, or
+  `prek` directly in docs, scripts, or CI. Always use `tox -e <env>`.
+- **GitHub Actions pinning**: pin to commit SHAs with a tag comment
+  (`actions/checkout@SHA # v4`), not mutable tags.
+- **Conventional commits**: all commit messages follow the conventional
+  commits format with devtools scopes.
+- **Renovate cooldown policy**: dependency updates must respect the
+  configured stabilityDays in `renovate.json5`. Rapid adoption (< 3 days)
+  is a supply-chain risk.
+- **Bot-authored PRs require human review**: `ansibuddy` and other bots
+  must not be the sole approver. At least one human review is required.
+- **Reusable workflow contracts**: changes to `.github/workflows/` in
+  team-devtools affect all downstream repos. Verify callers won't break.
+- **Agent skill integrity**: modifications to `.agents/skills/` must come
+  from the trusted sync workflow (`chore/sync-agent-skills` branch from
+  `ansibuddy`). Untrusted skill changes are a security risk.
+
+## Automated review patterns
+
+Copilot and CodeRabbit surface recurring categories. Address these
 proactively before pushing to avoid review round-trips:
 
 ### Supply-chain security
@@ -112,134 +224,153 @@ expose command-line arguments.
 
 ### Unused imports (Ruff F401)
 
-Copilot often flags unused imports. With Ruff `F` rules enabled, these fail CI.
-Remove unused imports or use the symbol (e.g. in a type annotation or
-assertion). Prefer trimming the import list over `# noqa: F401` unless the
-import is intentionally side-effect only.
+Remove unused imports or use the symbol. Prefer trimming the import list over
+`# noqa: F401` unless the import is intentionally side-effect only.
 
 ## Workflow
 
-1. **Ensure the PR branch is up to date with upstream main.** Before
-   reviewing or pushing fixes, rebase or merge `upstream/main` into the PR
-   branch. A stale base causes misleading CI results, merge conflicts, and
-   wasted review cycles. If the branch is behind, update it first:
+1. **Sync Branch:** Ensure the PR branch is up to date with upstream main.
 
    ```bash
    git fetch upstream
-   git rebase upstream/main   # or: git merge upstream/main
-   git push --force-with-lease
+   git rebase upstream/main
    ```
 
-2. After pushing a PR, wait for both CI and Copilot review.
-3. Check CI status and read all review comments.
-4. Fix all issues in a single commit (or minimal commits).
-5. Reply to each comment with a brief explanation of how it was resolved and
-   the commit hash (e.g., "Removed unused imports. Fixed in abc1234.").
-6. **Reply to every comment.** Resolve the thread only when the issue is
-   addressed or accepted. Leave disagreement or false-positive threads open
-   for a human reviewer to decide.
+2. **Review & Plan:** Check CI status and read all review comments. **Write
+   out a brief Action Plan** detailing which files you will edit to fix the
+   comments. This prevents ad-hoc fixes that miss the big picture.
+
+3. **Fix & Validate Locally:** Fix all issues in minimal commits. **Run local
+   validation before pushing** (`tox -e lint`, `tox -e py`) to ensure your
+   fix doesn't break something else.
+
+4. **Push:** `git push --force-with-lease`
+
+5. **Wait & Verify Remote CI:** Wait 2-3 minutes for remote CI pipelines to
+   run, then check their status. Some tests only run remotely; fix any
+   remote-only failures before proceeding.
+
+6. **Reply & Resolve (GraphQL):** Reply to *every single comment* with how it
+   was handled (fixed + hash, deferred + issue link, or disputed). **Only
+   resolve the threads you actually fixed or formally deferred.** Leave
+   disputed threads unresolved for human review.
+
+7. **Verify Actions:** Query the threads one last time to ensure every thread
+   has your reply, and that you didn't accidentally resolve a thread you
+   didn't fix.
 
 ### Checking CI status
 
-Always check CI checks as part of the review workflow. Fix failures before
-addressing review comments — a green build is a prerequisite for merge.
+Always check CI checks as part of the review workflow.
 
 ```bash
-# List failing checks (replace N with PR number)
-gh pr checks N --json name,state --jq '.[] | select(.state != "SUCCESS" and .state != "PENDING")'
-
-# Get the log link for a specific failed check
-gh pr checks N --json name,state,link --jq '.[] | select(.name == "CHECK_NAME") | .link'
+# After pushing, wait a few minutes, then list pending or failing checks
+gh pr checks N --json name,state --jq '.[] | select(.state != "SUCCESS")'
 
 # View failed job logs directly
 gh run view RUN_ID --log-failed 2>&1 | tail -80
 ```
 
-Common CI failures and how to fix them:
-
-- **prek (ruff)**: Run `tox -e lint` to reproduce. Long type annotations
-  and function signatures often need line wrapping.
-- **prek (mypy)**: Add type annotations to all new functions. Use the correct
-  `type: ignore` code (e.g., `[assignment]` vs `[method-assign]`). Run
-  `tox -e lint` to verify.
-- **prek (biome)**: Run `tox -e lint` to reproduce. Biome enforces formatting
-  for JSON, Markdown, and JavaScript files.
-- **prek (ansible-lint)**: Run `tox -e lint` to reproduce. Ensure playbooks
-  and roles follow ansible-lint rules.
-- **prek (tombi)**: Run `tox -e lint` to reproduce. TOML files must be
-  formatted with tombi.
-- **test failures**: Run `tox -e py` to reproduce. Update tests when behavior
-  changes.
-
 Do **not** run `ruff`, `mypy`, `pytest`, or `prek` directly — always use tox.
 See the `/tox` skill for the full environment reference.
 
-### Replying to review comments
+### Replying to and Resolving review threads (GraphQL ONLY)
 
-Post a reply using the REST API. Each reply must state **how** the issue was
-resolved and include the commit hash (not only the SHA):
+**CRITICAL:** Always use GraphQL (Base64 Node IDs) for both listing, replying,
+and resolving. Do NOT mix REST integer IDs with GraphQL Node IDs. Do NOT use
+`minimizeComment`.
 
-```bash
-gh api -X POST "repos/<upstream-owner>/<repo>/pulls/PR/comments/COMMENT_ID/replies" \
-  -f body="Removed the unused imports so Ruff F401 passes. Fixed in COMMIT_SHA."
-```
+**Step 1: List unresolved threads to get `THREAD_ID`**
 
-To get comment IDs: `gh api repos/<upstream-owner>/<repo>/pulls/PR/comments` and
-use each comment's `id`. Alternatively, reply in the GitHub PR UI, then resolve
-threads via GraphQL below.
-
-### Resolving review threads (GraphQL)
-
-**IMPORTANT:** Always use `resolveReviewThread` to resolve threads. Do NOT use
-`minimizeComment` — that hides the comment text but does NOT resolve the review
-thread, leaving it as an unresolved conversation on the PR.
-
-Replace `N` with the PR number and `THREAD_ID` with the `id` from
-`reviewThreads.nodes[].id` (from the list query). Filter nodes where
-`isResolved` is false if you only want to resolve open threads.
+Replace `N` with the PR number. This gets the `id` for each unresolved thread.
 
 ```bash
-# List unresolved threads (replace OWNER/REPO with actual values)
 gh api graphql -f query='{
   repository(owner: "<upstream-owner>", name: "<repo>") {
     pullRequest(number: N) {
       reviewThreads(first: 50) {
-        nodes { id isResolved comments(first:1) { nodes { body } } }
+        nodes { id isResolved comments(last: 5) { nodes { body author { login } } } }
       }
     }
   }
 }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, snippet: .comments.nodes[0].body[0:120]}'
+```
 
-# Resolve one thread
+**Step 2: Reply to the thread**
+
+Replace `THREAD_ID` with the `id` fetched above. State how the issue was
+resolved and the commit hash, OR explain why it is being disputed.
+
+```bash
+gh api graphql -f query='mutation {
+  addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: "THREAD_ID", body: "Removed the unused imports so Ruff F401 passes. Fixed in abc1234."}) {
+    comment { id }
+  }
+}'
+```
+
+**Step 3: Resolve the thread (CONDITIONAL)**
+
+Only run this if you successfully addressed the comment or filed a follow-up
+issue. **Do NOT run this if you are disputing the comment.**
+
+```bash
 gh api graphql -f query='mutation {
   resolveReviewThread(input: {threadId: "THREAD_ID"}) {
     thread { isResolved }
   }
 }'
-
-# Resolve multiple threads in a loop
-for tid in "THREAD_ID_1" "THREAD_ID_2"; do
-  gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"${tid}\"}) { thread { isResolved } } }"
-done
 ```
 
-1. Update the PR description to include the new commit(s).
-2. If CI failure is unrelated to your changes (e.g., flaky test, transient
-   network issue), fix it anyway — the PR owns the green build.
+*(You may combine Step 2 and Step 3 in a single bash script or execute them
+sequentially.)*
 
-### After pushing fixes: check for a new Copilot review
+### Verification Check
 
-Copilot may run again on new commits. Re-check whether it left a new review or
-line comments so you can reply and resolve any new threads.
+After replying and selectively resolving, run this query to list **all**
+threads (resolved and unresolved) with their latest replies. This differs from
+Step 1, which only shows unresolved threads.
+
+```bash
+gh api graphql -f query='{
+  repository(owner: "<upstream-owner>", name: "<repo>") {
+    pullRequest(number: N) {
+      reviewThreads(first: 50) {
+        nodes { id isResolved comments(last: 3) { nodes { body author { login } } } }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | {id, isResolved, lastReplyBy: .comments.nodes[-1].author.login, lastReplySnippet: .comments.nodes[-1].body[0:120]}'
+```
+
+* **Verify Replies:** Every thread must have a reply from you. If
+  `lastReplyBy` is still the original reviewer, that thread was missed.
+
+* **Verify Intentional State:** Unresolved threads should only be ones you
+  intentionally left open (disputed). Verify that any thread still showing
+  `isResolved: false` was left open on purpose. Do NOT blindly resolve all
+  threads just to clear the list.
+
+### After pushing fixes: check for new automated reviews
+
+Copilot and CodeRabbit may run again on new commits. Re-check whether
+they left new reviews or line comments so you can reply and resolve any
+new threads.
 
 ```bash
 # New Copilot review (replace N with PR number, ISO8601 with last push time)
 gh api repos/<upstream-owner>/<repo>/pulls/N/reviews --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .submitted_at > "ISO8601") | {submitted_at, state, body: .body[0:200]}'
 
-# New Copilot line comments (replace N and ISO8601)
-gh api repos/<upstream-owner>/<repo>/pulls/N/comments --jq '.[] | select(.user.login == "Copilot" and .created_at > "ISO8601") | {id, created_at, path, body: .body[0:150]}'
+# New Copilot inline comments
+gh api repos/<upstream-owner>/<repo>/pulls/N/comments --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .created_at > "ISO8601") | {created_at, path, body: .body[0:200]}'
+
+# New CodeRabbit review
+gh api repos/<upstream-owner>/<repo>/pulls/N/reviews --jq '.[] | select(.user.login == "coderabbitai[bot]" and .submitted_at > "ISO8601") | {submitted_at, state, body: .body[0:200]}'
+
+# New CodeRabbit inline comments
+gh api repos/<upstream-owner>/<repo>/pulls/N/comments --jq '.[] | select(.user.login == "coderabbitai[bot]" and .created_at > "ISO8601") | {created_at, path, body: .body[0:200]}'
 ```
 
-If both return nothing, no new Copilot activity. Otherwise, address new
-comments (reply with how it was resolved + commit hash, then resolve threads)
-and repeat this check after the next push.
+If both return nothing, no new automated review activity. Otherwise, address
+new comments (reply with how it was resolved + commit hash, then resolve
+threads) and repeat this check after the next push.


### PR DESCRIPTION
## Summary

- Port mature review patterns from the APME project into devtools pr-new, pr-review, and pr-contributor-review skills
- Adds structured self-review, Rule of Five multi-pass cold review, learning loop for automated findings, and CodeRabbit support

## Changes

### pr-new (v1.0 → v2.0)
- **Step 3: Self-review** — 9-question structured review forcing verification of every changed line against specific criteria (semantic truthfulness, exposure, caller safety, drift, dependencies, dead weight, consistency, adversarial scenarios, inherited contracts)
- **Step 3b: Rule of Five** — Five parallel review passes (Correctness/Safety, Fresh Eyes, Right Thing, Architecture, Adversarial) with aggregate/converge loop
- **Quality of life section** — Guidance for bundling non-code process improvements alongside features

### pr-review (v1.0 → v2.0)
- **Learning loop** — Every automated finding becomes a self-improvement signal for the pr-new self-review process
- **Evaluation principles** — Full set explaining *why* reviewers flag things (semantic truthfulness, information exposure, caller safety, drift, supply-chain mutability, internal consistency, adversarial input tracing, inherited contracts, dead weight)
- **DevTools-specific patterns** — tox-only, GHA pinning, Renovate cooldown, bot approval rules, reusable workflow contracts, agent skill integrity
- **CodeRabbit support** — Added alongside Copilot for detecting new reviews
- **Action Plan step** — Explicit requirement to plan before fixing
- **GraphQL-only workflow** — Consistent thread listing, reply, and resolution
- **Verification Check** — Final query confirming all threads handled

### pr-contributor-review (v1.0 → v1.1)
- Cross-reference to evaluation principles for consistent code assessment

## Test plan

- [ ] Skills render correctly (no markdown formatting issues)
- [ ] `pr-new` self-review questions are actionable and project-appropriate
- [ ] DevTools-specific patterns in `pr-review` are accurate for this org
- [ ] GraphQL commands use correct owner/repo placeholders

Human-led, AI-assisted (Cursor Agent)