### PR TITLE
fix(supply-chain-audit): detect zero-approval PRs and scan npm transitive deps

### DIFF
--- a/.agents/skills/td-supply-chain-audit/scripts/analyze.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/analyze.py
@@ -912,8 +912,44 @@ def detect_bot_only_approval(pr_audits: list[dict], prs: list[dict]) -> list[Fin
         approvals = audit.get("approvals", [])
         repo = audit.get("repo", "")
         pr_num = audit.get("pr_number", 0)
+        pr_author = audit.get("pr_author", "")
+        pr_title = audit.get("pr_title", "")
+        is_bot_pr = _is_bot_account(pr_author)
+        is_dep_only = any(kw in pr_title.lower() for kw in ("chore(deps)", "bump ", "update dependency", "lock file"))
 
         if not approvals:
+            if is_bot_pr and is_dep_only:
+                risk = RiskLevel.LOW
+                summary = f"PR #{pr_num}: bot dependency update merged with no approvals"
+            elif is_bot_pr:
+                risk = RiskLevel.MEDIUM
+                summary = f"PR #{pr_num}: bot PR merged with no approvals"
+            else:
+                risk = RiskLevel.CRITICAL
+                summary = f"PR #{pr_num}: human-authored PR merged with zero approvals by {pr_author}"
+
+            findings.append(
+                Finding(
+                    category=FindingCategory.BOT_ONLY_APPROVAL,
+                    risk_level=risk,
+                    repo=repo,
+                    summary=summary,
+                    details=(
+                        f"PR #{pr_num} ('{pr_title}') in {repo} by {pr_author} was merged "
+                        f"with no approvals at all. No human or bot reviewed this change."
+                    ),
+                    pr_number=pr_num,
+                    date=audit.get("merged_at"),
+                    evidence={
+                        "pr_author": pr_author,
+                        "pr_title": pr_title,
+                        "bot_approvers": [],
+                        "is_bot_pr": is_bot_pr,
+                        "is_dep_only": is_dep_only,
+                        "commit_count": audit.get("commit_count", 0),
+                    },
+                ),
+            )
             continue
 
         human_approvals = [a for a in approvals if not _is_bot_account(a["user"])]
@@ -922,14 +958,7 @@ def detect_bot_only_approval(pr_audits: list[dict], prs: list[dict]) -> list[Fin
         if human_approvals:
             continue
 
-        # All approvals are from bots
         bot_names = list({a["user"] for a in bot_approvals})
-        pr_author = audit.get("pr_author", "")
-        pr_title = audit.get("pr_title", "")
-
-        # Determine risk based on PR characteristics
-        is_bot_pr = _is_bot_account(pr_author)
-        is_dep_only = any(kw in pr_title.lower() for kw in ("chore(deps)", "bump ", "update dependency", "lock file"))
 
         if is_bot_pr and is_dep_only:
             risk = RiskLevel.LOW

--- a/.agents/skills/td-supply-chain-audit/scripts/collect.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/collect.py
@@ -931,50 +931,48 @@ def collect_package_inventory(repo: str) -> list[dict]:
             break
         time.sleep(RATE_LIMIT_SLEEP)
 
-    # Check for npm lock files (transitive deps)
-    npm_parsed = False
-    for lock_file in ["pnpm-lock.yaml", "package-lock.json"]:
-        if npm_parsed:
-            break
-        tree_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/trees/main")
-        if not tree_data or not isinstance(tree_data, dict):
-            break
-        for item in tree_data.get("tree", []):
-            if item.get("path") == lock_file and item.get("sha"):
-                blob_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/blobs/{item['sha']}")
-                if not blob_data or not isinstance(blob_data, dict):
-                    break
-                try:
-                    content = base64.b64decode(blob_data.get("content", "")).decode("utf-8")
-                    if lock_file == "pnpm-lock.yaml":
-                        pkgs = _parse_pnpm_lock_inventory(content)
-                    else:
-                        pkgs = _parse_package_lock_inventory(content)
-                    packages.extend({"name": p[0], "version": p[1], "ecosystem": "npm"} for p in pkgs)
-                    npm_parsed = True
-                except (ValueError, UnicodeDecodeError):
-                    pass
-                break
-        time.sleep(RATE_LIMIT_SLEEP)
-
-    if not npm_parsed:
-        endpoint = f"repos/{GITHUB_ORG}/{repo}/contents/package.json"
-        data = gh_api(endpoint)
-        if data and isinstance(data, dict) and data.get("content"):
-            try:
-                content = base64.b64decode(data["content"]).decode("utf-8")
-                pkg_json = json.loads(content)
-                for section in ("dependencies", "devDependencies"):
-                    for name, ver_spec in pkg_json.get(section, {}).items():
-                        ver = re.sub(r"^[~^>=<]*", "", ver_spec).strip()
-                        if ver and re.match(r"\d", ver):
-                            packages.append(
-                                {"name": name, "version": ver, "ecosystem": "npm"},
-                            )
-            except (json.JSONDecodeError, ValueError):
-                pass
+    npm_pkgs = _collect_npm_inventory(repo)
+    packages.extend(npm_pkgs)
 
     return packages
+
+
+def _collect_npm_inventory(repo: str) -> list[dict]:
+    """Collect npm package inventory from lock files or package.json fallback."""
+    tree_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/trees/main")
+    if tree_data and isinstance(tree_data, dict):
+        for lock_file in ["pnpm-lock.yaml", "package-lock.json"]:
+            for item in tree_data.get("tree", []):
+                if item.get("path") != lock_file or not item.get("sha"):
+                    continue
+                blob_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/blobs/{item['sha']}")
+                if not blob_data or not isinstance(blob_data, dict):
+                    continue
+                try:
+                    content = base64.b64decode(blob_data.get("content", "")).decode("utf-8")
+                except (ValueError, UnicodeDecodeError):
+                    continue
+                parser = _parse_pnpm_lock_inventory if lock_file == "pnpm-lock.yaml" else _parse_package_lock_inventory
+                return [{"name": p[0], "version": p[1], "ecosystem": "npm"} for p in parser(content)]
+            time.sleep(RATE_LIMIT_SLEEP)
+
+    endpoint = f"repos/{GITHUB_ORG}/{repo}/contents/package.json"
+    data = gh_api(endpoint)
+    if data and isinstance(data, dict) and data.get("content"):
+        try:
+            content = base64.b64decode(data["content"]).decode("utf-8")
+            pkg_json = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        packages = []
+        for section in ("dependencies", "devDependencies"):
+            for name, ver_spec in pkg_json.get(section, {}).items():
+                ver = re.sub(r"^[~^>=<]*", "", ver_spec).strip()
+                if ver and re.match(r"\d", ver):
+                    packages.append({"name": name, "version": ver, "ecosystem": "npm"})
+        return packages
+
+    return []
 
 
 def _parse_pnpm_lock_inventory(content: str) -> list[tuple[str, str]]:

--- a/.agents/skills/td-supply-chain-audit/scripts/collect.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/collect.py
@@ -64,7 +64,7 @@ GH_API_TIMEOUT_SECONDS = 120
 GH_VERSION_TIMEOUT_SECONDS = 10
 REGISTRY_REQUEST_TIMEOUT_SECONDS = 10
 OSV_REQUEST_TIMEOUT_SECONDS = 30
-OSV_BATCH_SIZE = 100
+OSV_BATCH_SIZE = 1000
 OSV_BATCH_SLEEP_SECONDS = 1
 MAX_COMMIT_MSG_LEN = 120
 GITHUB_EXT_PREFIX_LEN = 7
@@ -931,25 +931,97 @@ def collect_package_inventory(repo: str) -> list[dict]:
             break
         time.sleep(RATE_LIMIT_SLEEP)
 
-    # Check for npm lock file (too large for contents API, use a different approach)
-    # For package.json we can get direct deps
-    endpoint = f"repos/{GITHUB_ORG}/{repo}/contents/package.json"
-    data = gh_api(endpoint)
-    if data and isinstance(data, dict) and data.get("content"):
-        try:
-            content = base64.b64decode(data["content"]).decode("utf-8")
-            pkg_json = json.loads(content)
-            for section in ("dependencies", "devDependencies"):
-                for name, ver_spec in pkg_json.get(section, {}).items():
-                    # Strip version prefixes (^, ~, >=)
-                    ver = re.sub(r"^[~^>=<]*", "", ver_spec).strip()
-                    if ver and re.match(r"\d", ver):
-                        packages.append(
-                            {"name": name, "version": ver, "ecosystem": "npm"},
-                        )
-        except (json.JSONDecodeError, ValueError):
-            pass
+    # Check for npm lock files (transitive deps)
+    npm_parsed = False
+    for lock_file in ["pnpm-lock.yaml", "package-lock.json"]:
+        if npm_parsed:
+            break
+        tree_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/trees/main")
+        if not tree_data or not isinstance(tree_data, dict):
+            break
+        for item in tree_data.get("tree", []):
+            if item.get("path") == lock_file and item.get("sha"):
+                blob_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/blobs/{item['sha']}")
+                if not blob_data or not isinstance(blob_data, dict):
+                    break
+                try:
+                    content = base64.b64decode(blob_data.get("content", "")).decode("utf-8")
+                    if lock_file == "pnpm-lock.yaml":
+                        pkgs = _parse_pnpm_lock_inventory(content)
+                    else:
+                        pkgs = _parse_package_lock_inventory(content)
+                    packages.extend({"name": p[0], "version": p[1], "ecosystem": "npm"} for p in pkgs)
+                    npm_parsed = True
+                except (ValueError, UnicodeDecodeError):
+                    pass
+                break
+        time.sleep(RATE_LIMIT_SLEEP)
 
+    if not npm_parsed:
+        endpoint = f"repos/{GITHUB_ORG}/{repo}/contents/package.json"
+        data = gh_api(endpoint)
+        if data and isinstance(data, dict) and data.get("content"):
+            try:
+                content = base64.b64decode(data["content"]).decode("utf-8")
+                pkg_json = json.loads(content)
+                for section in ("dependencies", "devDependencies"):
+                    for name, ver_spec in pkg_json.get(section, {}).items():
+                        ver = re.sub(r"^[~^>=<]*", "", ver_spec).strip()
+                        if ver and re.match(r"\d", ver):
+                            packages.append(
+                                {"name": name, "version": ver, "ecosystem": "npm"},
+                            )
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+    return packages
+
+
+def _parse_pnpm_lock_inventory(content: str) -> list[tuple[str, str]]:
+    """Extract (name, version) pairs from a pnpm-lock.yaml file.
+
+    Parses the packages section where entries look like:
+      '@scope/name@1.2.3':
+        resolution: ...
+
+    """
+    packages = []
+    seen = set()
+    in_packages = False
+    pkg_pattern = re.compile(r"^\s{2}'?(@?[^@'\s]+(?:/@?[^@'\s]+)?)@(\d+[^(':\s]*)")
+
+    for line in content.split("\n"):
+        if line.strip() == "packages:":
+            in_packages = True
+            continue
+        if not in_packages:
+            continue
+        m = pkg_pattern.match(line)
+        if m:
+            name, version = m.group(1), m.group(2)
+            key = (name, version)
+            if key not in seen:
+                seen.add(key)
+                packages.append((name, version))
+
+    return packages
+
+
+def _parse_package_lock_inventory(content: str) -> list[tuple[str, str]]:
+    """Extract (name, version) pairs from a package-lock.json file."""
+    packages = []
+    try:
+        data = json.loads(content)
+        pkgs = data.get("packages", {})
+        for path, info in pkgs.items():
+            if not path:
+                continue
+            name = path.split("node_modules/")[-1] if "node_modules/" in path else path
+            version = info.get("version", "")
+            if name and version:
+                packages.append((name, version))
+    except (json.JSONDecodeError, ValueError):
+        pass
     return packages
 
 


### PR DESCRIPTION
## Summary

Fixes two detection gaps in the supply chain audit skill found during weekly audits.

### 1. Zero-approval PRs now detected

PRs merged without any approvals were silently skipped by the bot-only-approval check. The code did `if not approvals: continue` which means a human-authored PR merged with zero reviews produced no finding at all.

Now these are flagged with appropriate risk levels:
- **Critical**: human-authored PR merged with zero approvals
- **Medium**: bot PR merged with zero approvals
- **Low**: bot dependency update merged with zero approvals

### 2. npm transitive dependencies now scanned

Previously only direct deps from `package.json` were checked against OSV.dev. Transitive dependencies were completely invisible.

Now parses `pnpm-lock.yaml` and `package-lock.json` via the Git blob API for the full dependency tree. OSV batch size bumped from 100 to 1000 for faster scanning (~5s for 1650 packages). Deduplicates pnpm qualified entries to avoid duplicate findings.

Tested on vscode-ansible: went from ~200 packages scanned to 1764 (1650 npm + 114 PyPI). Found vulnerabilities in `diff` and `file-type` that were previously invisible.

## Test plan

- [x] Re-ran analysis on existing audit cache, zero-approval PR correctly flagged as critical
- [x] pnpm-lock.yaml parser tested on vscode-ansible (1650 deduplicated packages)
- [x] OSV batch scan completes in ~5s for 1764 packages
- [x] Found new npm vulns previously missed