### PR TITLE
feat: move guardian cron + Pages workflows into team-devtools

### DIFF
--- a/.agents/skills/td-guardian/SKILL.md
+++ b/.agents/skills/td-guardian/SKILL.md
@@ -218,10 +218,31 @@ Parse the JSON output and explain each cluster:
 
 ## Scheduled CI / GitHub Pages
 
-Scheduled dashboard workflows currently still live in the personal ops repo
-(`sathyapramod/devtools-guardian`) until they are moved into team-devtools.
-Baselines use the published Pages `snapshot.json` (not commits to protected
-`main`). A follow-up PR will relocate `.github/workflows/guardian-*.yml` here.
+Workflows live in this repo under `.github/workflows/guardian-*.yml`:
+
+| Workflow | Purpose |
+|----------|---------|
+| `guardian-daily.yml` | Twice-daily dashboard (PRs, CI, deps, coverage, correlation) |
+| `guardian-weekly.yml` | Monday security audit + full `td-supply-chain-audit` |
+| `guardian-on-demand.yml` | Manual Sonar/Codecov/supply-chain fetches (artifact upload) |
+| `guardian-watchdog.yml` | Stale/failed run recovery + issue alerts |
+
+Dashboard output is written to `guardian-site/` (not mkdocs `docs/`) and
+deployed to GitHub Pages. Cross-run deltas load the previous baseline from
+the published Pages `snapshot.json` (never committed to protected `main`).
+
+Expected Pages URL once enabled:
+`https://ansible.github.io/team-devtools/`
+
+### Required repo setup (maintainers)
+
+1. **Settings → Pages** — Source: GitHub Actions
+2. Create environment **`github-pages`** (used by daily/weekly deploy jobs)
+3. Add repository (or org) secrets:
+   - `SONAR_TOKEN` — SonarCloud API
+   - `AUDIT_GH_TOKEN` — PAT for supply-chain / cross-repo audit fetches
+   - `GUARDIAN_GH_TOKEN` — PAT that can `workflow_dispatch` guardian workflows
+     (and powers the dashboard refresh button)
 
 ## Reference
 

--- a/.agents/skills/td-guardian/scripts/generate_dashboard.py
+++ b/.agents/skills/td-guardian/scripts/generate_dashboard.py
@@ -1148,7 +1148,7 @@ TOOLBAR_CSS = """
 """
 
 TOOLBAR_JS = """
-const REPO = 'sathyapramod/devtools-guardian'; // ops host until workflows move to team-devtools
+const REPO = 'ansible/team-devtools';
 const WORKFLOW = 'guardian-daily.yml';
 const MAX_DAILY_TRIGGERS = 12;
 const AUTO_REFRESH_MS = 30 * 60 * 1000;

--- a/.github/workflows/guardian-daily.yml
+++ b/.github/workflows/guardian-daily.yml
@@ -1,0 +1,150 @@
+---
+name: Guardian Daily Check
+
+on:
+  schedule:
+    # 08:00 and 15:00 IST (UTC+5:30)
+    - cron: "30 2 * * *"
+    - cron: "30 9 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".agents/skills/td-guardian/**"
+      - ".github/workflows/guardian-daily.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: guardian-pages
+  cancel-in-progress: true
+
+env:
+  SKILL_ROOT: .agents/skills/td-guardian
+  SITE_DIR: guardian-site
+
+jobs:
+  fetch-and-deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Ensure report directories
+        run: mkdir -p "${SKILL_ROOT}/reports" "${SITE_DIR}"
+
+      - name: Fetch open PRs
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_open_prs.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          > "${SKILL_ROOT}/reports/open-prs.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch CI status
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_ci_status.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          > "${SKILL_ROOT}/reports/ci-status.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch dependency PRs
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_renovate_prs.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          > "${SKILL_ROOT}/reports/renovate-prs.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch Codecov coverage
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_codecov.py"
+          --codecov-config "${SKILL_ROOT}/config/codecov.json"
+          > "${SKILL_ROOT}/reports/codecov.json"
+
+      - name: Fetch SonarCloud quality gates
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_sonar_gates.py"
+          --sonar-config "${SKILL_ROOT}/config/sonar.json"
+          > "${SKILL_ROOT}/reports/sonar-gates.json"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Correlate CI failures
+        run: >
+          python3 "${SKILL_ROOT}/scripts/correlate_failures.py"
+          --ci "${SKILL_ROOT}/reports/ci-status.json"
+          --renovate "${SKILL_ROOT}/reports/renovate-prs.json"
+          -o "${SKILL_ROOT}/reports/correlation.json"
+
+      - name: Fetch supply-chain audit
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_supply_chain.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          --days 7 --skip-vulns
+          -o "${SKILL_ROOT}/reports/supply-chain.json"
+        env:
+          GH_TOKEN: ${{ secrets.AUDIT_GH_TOKEN }}
+
+      - name: Load previous snapshot from Pages
+        run: |
+          SNAPSHOT_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/snapshot.json"
+          if curl -fsSL "$SNAPSHOT_URL" -o "${SKILL_ROOT}/reports/previous-snapshot.json"; then
+            echo "Loaded previous snapshot from $SNAPSHOT_URL"
+          else
+            echo "No previous snapshot published yet (first run or Pages miss)"
+            rm -f "${SKILL_ROOT}/reports/previous-snapshot.json"
+          fi
+
+      - name: Diff against previous snapshot
+        run: |
+          python3 "${SKILL_ROOT}/scripts/diff_snapshots.py" \
+            --prs "${SKILL_ROOT}/reports/open-prs.json" \
+            --ci "${SKILL_ROOT}/reports/ci-status.json" \
+            --renovate "${SKILL_ROOT}/reports/renovate-prs.json" \
+            --codecov "${SKILL_ROOT}/reports/codecov.json" \
+            --sonar "${SKILL_ROOT}/reports/sonar-gates.json" \
+            --previous "${SKILL_ROOT}/reports/previous-snapshot.json" \
+            --output "${SKILL_ROOT}/reports/changes.json" \
+            --write-previous "${SKILL_ROOT}/reports/previous-snapshot.json"
+
+      - name: Generate HTML dashboard
+        run: |
+          python3 "${SKILL_ROOT}/scripts/generate_dashboard.py" \
+            --prs "${SKILL_ROOT}/reports/open-prs.json" \
+            --ci "${SKILL_ROOT}/reports/ci-status.json" \
+            --renovate "${SKILL_ROOT}/reports/renovate-prs.json" \
+            --codecov "${SKILL_ROOT}/reports/codecov.json" \
+            --sonar "${SKILL_ROOT}/reports/sonar-gates.json" \
+            --correlation "${SKILL_ROOT}/reports/correlation.json" \
+            --supply-chain "${SKILL_ROOT}/reports/supply-chain.json" \
+            --changes "${SKILL_ROOT}/reports/changes.json" \
+            --output "${SITE_DIR}/index.html"
+        env:
+          GUARDIAN_GH_TOKEN: ${{ secrets.GUARDIAN_GH_TOKEN }}
+
+      - name: Publish snapshot baseline with Pages
+        run: |
+          cp "${SKILL_ROOT}/reports/previous-snapshot.json" "${SITE_DIR}/snapshot.json"
+          cp "${SKILL_ROOT}/reports/changes.json" "${SITE_DIR}/changes.json"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: guardian-site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/guardian-on-demand.yml
+++ b/.github/workflows/guardian-on-demand.yml
@@ -1,0 +1,94 @@
+---
+name: Guardian On-Demand
+
+# Manual Sonar / Codecov / supply-chain fetches without committing to protected main.
+# Reports are uploaded as Actions artifacts. For a full dashboard refresh, run
+# Guardian Daily (or Weekly) instead — or set deploy_pages to dispatch Daily.
+
+on:
+  workflow_dispatch:
+    inputs:
+      security_audit:
+        description: "Fetch SonarCloud + Codecov"
+        type: boolean
+        default: true
+      supply_chain:
+        description: "Fetch supply-chain signals"
+        type: boolean
+        default: true
+      deploy_pages:
+        description: "Also dispatch Guardian Daily (Pages dashboard refresh)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: guardian-on-demand
+  cancel-in-progress: true
+
+env:
+  SKILL_ROOT: .agents/skills/td-guardian
+
+jobs:
+  fetch:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Ensure report directories
+        run: mkdir -p "${SKILL_ROOT}/reports"
+
+      - name: Fetch Codecov coverage
+        if: ${{ inputs.security_audit }}
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_codecov.py"
+          --codecov-config "${SKILL_ROOT}/config/codecov.json"
+          > "${SKILL_ROOT}/reports/codecov.json"
+
+      - name: Fetch SonarCloud quality gates
+        if: ${{ inputs.security_audit }}
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_sonar_gates.py"
+          --sonar-config "${SKILL_ROOT}/config/sonar.json"
+          > "${SKILL_ROOT}/reports/sonar-gates.json"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Fetch supply-chain audit
+        if: ${{ inputs.supply_chain }}
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_supply_chain.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          --days 7 --skip-vulns
+          -o "${SKILL_ROOT}/reports/supply-chain.json"
+        env:
+          GH_TOKEN: ${{ secrets.AUDIT_GH_TOKEN }}
+
+      - name: Upload report artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: guardian-on-demand-reports
+          path: .agents/skills/td-guardian/reports/
+          if-no-files-found: warn
+
+      - name: Dispatch Guardian Daily for Pages refresh
+        if: ${{ inputs.deploy_pages }}
+        env:
+          GH_TOKEN: ${{ secrets.GUARDIAN_GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GUARDIAN_GH_TOKEN is required to dispatch guardian-daily.yml"
+            exit 1
+          fi
+          gh workflow run guardian-daily.yml
+          echo "Dispatched guardian-daily.yml at $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/guardian-watchdog.yml
+++ b/.github/workflows/guardian-watchdog.yml
@@ -1,0 +1,327 @@
+---
+name: Guardian Watchdog
+
+on:
+  schedule:
+    - cron: "30 4 * * *" # 10:00 AM IST — checks the 8 AM IST daily run
+    - cron: "30 11 * * *" # 5:00 PM IST — checks the 3 PM IST daily run
+    - cron: "0 17 * * *" # 10:30 PM IST — afternoon backstop
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: write
+  issues: write
+
+concurrency:
+  group: guardian-watchdog
+  cancel-in-progress: true
+
+jobs:
+  check-daily:
+    runs-on: ubuntu-24.04
+    outputs:
+      daily_dispatched: ${{ steps.dispatch.outputs.dispatched }}
+      daily_failed: ${{ steps.failure.outputs.daily_failed }}
+      daily_failed_url: ${{ steps.failure.outputs.daily_failed_url }}
+    steps:
+      - name: Check daily workflow freshness
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          THRESHOLD_HOURS=8
+
+          echo "::group::Fetching recent daily workflow runs"
+          LATEST_RUN=$(gh run list \
+            --workflow guardian-daily.yml \
+            --limit 5 \
+            --json status,conclusion,updatedAt \
+            --jq '
+              [.[] | select(
+                .conclusion == "success" or
+                .status == "in_progress" or
+                .status == "queued"
+              )] | first
+            ')
+          echo "Latest qualifying run: $LATEST_RUN"
+          echo "::endgroup::"
+
+          if [ -z "$LATEST_RUN" ] || [ "$LATEST_RUN" = "null" ]; then
+            echo "No recent successful or active run found"
+            echo "daily_stale=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATUS=$(echo "$LATEST_RUN" | jq -r '.status // empty')
+          if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
+            echo "A run is currently $STATUS — no action needed"
+            echo "daily_stale=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_RUN_TIME=$(echo "$LATEST_RUN" | jq -r '.updatedAt')
+          LAST_RUN_EPOCH=$(date -u -d "$LAST_RUN_TIME" +%s)
+          NOW_EPOCH=$(date -u +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - LAST_RUN_EPOCH) / 3600 ))
+
+          echo "Last successful run: $LAST_RUN_TIME ($AGE_HOURS hours ago)"
+          echo "Threshold: $THRESHOLD_HOURS hours"
+
+          if [ "$AGE_HOURS" -ge "$THRESHOLD_HOURS" ]; then
+            echo "STALE: Last run was $AGE_HOURS hours ago"
+            echo "daily_stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "FRESH: Last run was $AGE_HOURS hours ago"
+            echo "daily_stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect failed daily run
+        id: failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LATEST=$(gh run list \
+            --workflow guardian-daily.yml \
+            --limit 1 \
+            --json status,conclusion,url,updatedAt,displayTitle \
+            --jq '.[0]')
+          echo "Latest daily run: $LATEST"
+
+          STATUS=$(echo "$LATEST" | jq -r '.status // empty')
+          CONCLUSION=$(echo "$LATEST" | jq -r '.conclusion // empty')
+          URL=$(echo "$LATEST" | jq -r '.url // empty')
+
+          if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" = "failure" ]; then
+            echo "FAIL: Latest daily run failed"
+            echo "daily_failed=true" >> "$GITHUB_OUTPUT"
+            echo "daily_failed_url=$URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "Latest daily run is not a failure (status=$STATUS conclusion=$CONCLUSION)"
+            echo "daily_failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch daily workflow
+        id: dispatch
+        if: steps.check.outputs.daily_stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GUARDIAN_GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GUARDIAN_GH_TOKEN is not set — cannot dispatch recovery run"
+            exit 1
+          fi
+          echo "Dispatching guardian-daily.yml..."
+          gh workflow run guardian-daily.yml
+          echo "dispatched=true" >> "$GITHUB_OUTPUT"
+          echo "Daily workflow dispatched at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  check-weekly:
+    runs-on: ubuntu-24.04
+    outputs:
+      weekly_dispatched: ${{ steps.dispatch.outputs.dispatched }}
+      weekly_failed: ${{ steps.failure.outputs.weekly_failed }}
+      weekly_failed_url: ${{ steps.failure.outputs.weekly_failed_url }}
+    steps:
+      - name: Check if today is Monday
+        id: day-check
+        run: |
+          DAY_OF_WEEK=$(date -u +%u)
+          echo "Day of week: $DAY_OF_WEEK (1=Monday)"
+          if [ "$DAY_OF_WEEK" = "1" ]; then
+            echo "is_monday=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_monday=false" >> "$GITHUB_OUTPUT"
+            echo "Not Monday — skipping weekly check"
+          fi
+
+      - name: Check weekly workflow freshness
+        id: check
+        if: steps.day-check.outputs.is_monday == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          THRESHOLD_HOURS=24
+
+          LATEST_RUN=$(gh run list \
+            --workflow guardian-weekly.yml \
+            --limit 5 \
+            --json status,conclusion,updatedAt \
+            --jq '
+              [.[] | select(
+                .conclusion == "success" or
+                .status == "in_progress" or
+                .status == "queued"
+              )] | first
+            ')
+          echo "Latest qualifying weekly run: $LATEST_RUN"
+
+          if [ -z "$LATEST_RUN" ] || [ "$LATEST_RUN" = "null" ]; then
+            echo "No recent successful or active weekly run found"
+            echo "weekly_stale=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATUS=$(echo "$LATEST_RUN" | jq -r '.status // empty')
+          if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
+            echo "Weekly run is currently $STATUS — no action needed"
+            echo "weekly_stale=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_RUN_TIME=$(echo "$LATEST_RUN" | jq -r '.updatedAt')
+          LAST_RUN_EPOCH=$(date -u -d "$LAST_RUN_TIME" +%s)
+          NOW_EPOCH=$(date -u +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - LAST_RUN_EPOCH) / 3600 ))
+
+          echo "Last successful weekly run: $LAST_RUN_TIME ($AGE_HOURS hours ago)"
+
+          if [ "$AGE_HOURS" -ge "$THRESHOLD_HOURS" ]; then
+            echo "STALE: Last weekly run was $AGE_HOURS hours ago"
+            echo "weekly_stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "FRESH: Last weekly run was $AGE_HOURS hours ago"
+            echo "weekly_stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect failed weekly run
+        id: failure
+        if: steps.day-check.outputs.is_monday == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LATEST=$(gh run list \
+            --workflow guardian-weekly.yml \
+            --limit 1 \
+            --json status,conclusion,url,updatedAt \
+            --jq '.[0]')
+          echo "Latest weekly run: $LATEST"
+
+          STATUS=$(echo "$LATEST" | jq -r '.status // empty')
+          CONCLUSION=$(echo "$LATEST" | jq -r '.conclusion // empty')
+          URL=$(echo "$LATEST" | jq -r '.url // empty')
+
+          if [ "$STATUS" = "completed" ] && [ "$CONCLUSION" = "failure" ]; then
+            echo "FAIL: Latest weekly run failed"
+            echo "weekly_failed=true" >> "$GITHUB_OUTPUT"
+            echo "weekly_failed_url=$URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "Latest weekly run is not a failure (status=$STATUS conclusion=$CONCLUSION)"
+            echo "weekly_failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch weekly workflow
+        id: dispatch
+        if: steps.check.outputs.weekly_stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GUARDIAN_GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GUARDIAN_GH_TOKEN is not set — cannot dispatch recovery run"
+            exit 1
+          fi
+          echo "Dispatching guardian-weekly.yml..."
+          gh workflow run guardian-weekly.yml
+          echo "dispatched=true" >> "$GITHUB_OUTPUT"
+          echo "Weekly workflow dispatched at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  notify:
+    runs-on: ubuntu-24.04
+    needs: [check-daily, check-weekly]
+    if: |
+      always() && (
+        needs.check-daily.outputs.daily_dispatched == 'true' ||
+        needs.check-weekly.outputs.weekly_dispatched == 'true' ||
+        needs.check-daily.outputs.daily_failed == 'true' ||
+        needs.check-weekly.outputs.weekly_failed == 'true'
+      )
+    steps:
+      - name: Create or update notification issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          DAILY_DISPATCHED: ${{ needs.check-daily.outputs.daily_dispatched }}
+          WEEKLY_DISPATCHED: ${{ needs.check-weekly.outputs.weekly_dispatched }}
+          DAILY_FAILED: ${{ needs.check-daily.outputs.daily_failed }}
+          WEEKLY_FAILED: ${{ needs.check-weekly.outputs.weekly_failed }}
+          DAILY_FAILED_URL: ${{ needs.check-daily.outputs.daily_failed_url }}
+          WEEKLY_FAILED_URL: ${{ needs.check-weekly.outputs.weekly_failed_url }}
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          TITLE="Watchdog: Guardian health alert ($TODAY)"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          BODY="## Watchdog Alert\n\n"
+          BODY+="Detected at: \`${NOW}\`\n\n"
+
+          if [ "$DAILY_FAILED" = "true" ]; then
+            BODY+="- :x: **Daily workflow failed**"
+            if [ -n "$DAILY_FAILED_URL" ]; then
+              BODY+=" — [view run](${DAILY_FAILED_URL})"
+            fi
+            BODY+="\n"
+          fi
+          if [ "$WEEKLY_FAILED" = "true" ]; then
+            BODY+="- :x: **Weekly workflow failed**"
+            if [ -n "$WEEKLY_FAILED_URL" ]; then
+              BODY+=" — [view run](${WEEKLY_FAILED_URL})"
+            fi
+            BODY+="\n"
+          fi
+          if [ "$DAILY_DISPATCHED" = "true" ]; then
+            BODY+="- :warning: **Daily workflow** was stale — dispatched recovery run\n"
+          fi
+          if [ "$WEEKLY_DISPATCHED" = "true" ]; then
+            BODY+="- :warning: **Weekly workflow** was stale — dispatched recovery run\n"
+          fi
+
+          BODY+="\n---\n"
+          BODY+="*This issue was created automatically by the Guardian watchdog.*"
+
+          gh label create "watchdog" \
+            --description "Automated alerts from Guardian watchdog" \
+            --color "FF6B35" \
+            --force 2>/dev/null || true
+
+          EXISTING_NUM=$(gh issue list \
+            --label "watchdog" \
+            --state open \
+            --search "Watchdog: Guardian health alert ($TODAY) in:title" \
+            --json number,title \
+            --jq "[.[] | select(.title == \"Watchdog: Guardian health alert ($TODAY)\")] | first | .number // empty")
+
+          if [ -n "$EXISTING_NUM" ]; then
+            echo "Open watchdog issue #$EXISTING_NUM exists — commenting"
+            COMMENT="### Watchdog update (\`${NOW}\`)\n\n"
+            if [ "$DAILY_FAILED" = "true" ]; then
+              COMMENT+="- Daily still/again failing"
+              if [ -n "$DAILY_FAILED_URL" ]; then
+                COMMENT+=" — [run](${DAILY_FAILED_URL})"
+              fi
+              COMMENT+="\n"
+            fi
+            if [ "$WEEKLY_FAILED" = "true" ]; then
+              COMMENT+="- Weekly still/again failing"
+              if [ -n "$WEEKLY_FAILED_URL" ]; then
+                COMMENT+=" — [run](${WEEKLY_FAILED_URL})"
+              fi
+              COMMENT+="\n"
+            fi
+            if [ "$DAILY_DISPATCHED" = "true" ]; then
+              COMMENT+="- Dispatched daily recovery run\n"
+            fi
+            if [ "$WEEKLY_DISPATCHED" = "true" ]; then
+              COMMENT+="- Dispatched weekly recovery run\n"
+            fi
+            gh issue comment "$EXISTING_NUM" --body "$(echo -e "$COMMENT")"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --body "$(echo -e "$BODY")" \
+              --label "watchdog"
+          fi

--- a/.github/workflows/guardian-weekly.yml
+++ b/.github/workflows/guardian-weekly.yml
@@ -1,0 +1,181 @@
+---
+name: Guardian Weekly Security Audit
+
+on:
+  schedule:
+    # Monday 08:00 IST (UTC+5:30)
+    - cron: "30 2 * * 1"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".agents/skills/td-guardian/**"
+      - ".agents/skills/td-supply-chain-audit/**"
+      - ".github/workflows/guardian-weekly.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: guardian-pages
+  cancel-in-progress: true
+
+env:
+  SKILL_ROOT: .agents/skills/td-guardian
+  AUDIT_ROOT: .agents/skills/td-supply-chain-audit
+  SITE_DIR: guardian-site
+
+jobs:
+  fetch-and-deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Ensure report directories
+        run: mkdir -p "${SKILL_ROOT}/reports" "${SITE_DIR}"
+
+      - name: Fetch open PRs
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_open_prs.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          > "${SKILL_ROOT}/reports/open-prs.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch CI status
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_ci_status.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          > "${SKILL_ROOT}/reports/ci-status.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch dependency PRs
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_renovate_prs.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          > "${SKILL_ROOT}/reports/renovate-prs.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch Codecov coverage
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_codecov.py"
+          --codecov-config "${SKILL_ROOT}/config/codecov.json"
+          > "${SKILL_ROOT}/reports/codecov.json"
+
+      - name: Fetch SonarCloud quality gates
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_sonar_gates.py"
+          --sonar-config "${SKILL_ROOT}/config/sonar.json"
+          > "${SKILL_ROOT}/reports/sonar-gates.json"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Correlate CI failures
+        run: >
+          python3 "${SKILL_ROOT}/scripts/correlate_failures.py"
+          --ci "${SKILL_ROOT}/reports/ci-status.json"
+          --renovate "${SKILL_ROOT}/reports/renovate-prs.json"
+          -o "${SKILL_ROOT}/reports/correlation.json"
+
+      - name: Fetch supply-chain audit
+        run: >
+          python3 "${SKILL_ROOT}/scripts/fetch_supply_chain.py"
+          --repos-file "${SKILL_ROOT}/config/repos.json"
+          --days 7 --skip-vulns
+          -o "${SKILL_ROOT}/reports/supply-chain.json"
+        env:
+          GH_TOKEN: ${{ secrets.AUDIT_GH_TOKEN }}
+
+      - name: Run full security audit (collect + analyze)
+        run: |
+          START_DATE=$(date -d '7 days ago' +%Y-%m-%d)
+          END_DATE=$(date -d 'yesterday' +%Y-%m-%d)
+          CACHE_DIR=".supply-chain-audit/cache"
+
+          python3 "${AUDIT_ROOT}/scripts/collect.py" \
+            --start "$START_DATE" --end "$END_DATE" --cache-dir "$CACHE_DIR"
+
+          python3 "${AUDIT_ROOT}/scripts/analyze.py" \
+            --cache-dir "$CACHE_DIR"
+        env:
+          GH_TOKEN: ${{ secrets.AUDIT_GH_TOKEN }}
+          PYTHONUNBUFFERED: "1"
+
+      - name: Convert audit to dashboard format
+        run: |
+          CACHE_HASH=$(ls .supply-chain-audit/cache/ | head -1)
+          python3 "${SKILL_ROOT}/scripts/convert_audit.py" \
+            --cache-dir ".supply-chain-audit/cache/$CACHE_HASH" \
+            -o "${SKILL_ROOT}/reports/security-audit.json"
+
+      - name: Generate full audit report
+        run: |
+          CACHE_HASH=$(ls .supply-chain-audit/cache/ | head -1)
+          python3 "${AUDIT_ROOT}/scripts/report.py" \
+            --cache-dir ".supply-chain-audit/cache/$CACHE_HASH" \
+            --output "${SITE_DIR}/audit.html"
+
+      - name: Load previous snapshot from Pages
+        run: |
+          SNAPSHOT_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/snapshot.json"
+          if curl -fsSL "$SNAPSHOT_URL" -o "${SKILL_ROOT}/reports/previous-snapshot.json"; then
+            echo "Loaded previous snapshot from $SNAPSHOT_URL"
+          else
+            echo "No previous snapshot published yet (first run or Pages miss)"
+            rm -f "${SKILL_ROOT}/reports/previous-snapshot.json"
+          fi
+
+      - name: Diff against previous snapshot
+        run: |
+          python3 "${SKILL_ROOT}/scripts/diff_snapshots.py" \
+            --prs "${SKILL_ROOT}/reports/open-prs.json" \
+            --ci "${SKILL_ROOT}/reports/ci-status.json" \
+            --renovate "${SKILL_ROOT}/reports/renovate-prs.json" \
+            --codecov "${SKILL_ROOT}/reports/codecov.json" \
+            --sonar "${SKILL_ROOT}/reports/sonar-gates.json" \
+            --previous "${SKILL_ROOT}/reports/previous-snapshot.json" \
+            --output "${SKILL_ROOT}/reports/changes.json" \
+            --write-previous "${SKILL_ROOT}/reports/previous-snapshot.json"
+
+      - name: Generate HTML dashboard
+        run: |
+          python3 "${SKILL_ROOT}/scripts/generate_dashboard.py" \
+            --prs "${SKILL_ROOT}/reports/open-prs.json" \
+            --ci "${SKILL_ROOT}/reports/ci-status.json" \
+            --renovate "${SKILL_ROOT}/reports/renovate-prs.json" \
+            --codecov "${SKILL_ROOT}/reports/codecov.json" \
+            --sonar "${SKILL_ROOT}/reports/sonar-gates.json" \
+            --correlation "${SKILL_ROOT}/reports/correlation.json" \
+            --supply-chain "${SKILL_ROOT}/reports/supply-chain.json" \
+            --security-audit "${SKILL_ROOT}/reports/security-audit.json" \
+            --changes "${SKILL_ROOT}/reports/changes.json" \
+            --output "${SITE_DIR}/index.html"
+        env:
+          GUARDIAN_GH_TOKEN: ${{ secrets.GUARDIAN_GH_TOKEN }}
+
+      - name: Publish snapshot baseline with Pages
+        run: |
+          cp "${SKILL_ROOT}/reports/previous-snapshot.json" "${SITE_DIR}/snapshot.json"
+          cp "${SKILL_ROOT}/reports/changes.json" "${SITE_DIR}/changes.json"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: guardian-site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ src/team_devtools/_version.py
 .ansible
 coverage.lcov
 .architecture-diagrams/
+guardian-site/


### PR DESCRIPTION
## Summary
- Port `guardian-daily`, `guardian-weekly`, `guardian-on-demand`, and `guardian-watchdog` workflows from `sathyapramod/devtools-guardian` into `ansible/team-devtools`
- Run scripts from `.agents/skills/td-guardian/` (weekly uses in-repo `td-supply-chain-audit` instead of cloning)
- Publish dashboard to `guardian-site/` (avoids clobbering mkdocs `docs/`) with Pages `snapshot.json` baseline (no push to protected `main`)
- Convert on-demand to artifact upload (+ optional daily dispatch); no commits to `main`
- Point dashboard refresh at `ansible/team-devtools`; document required Pages env + secrets in `td-guardian` SKILL.md

## Maintainer setup (required before cron works)
1. **Settings → Pages** → Source: GitHub Actions
2. Create environment **`github-pages`**
3. Add secrets: `SONAR_TOKEN`, `AUDIT_GH_TOKEN`, `GUARDIAN_GH_TOKEN`
4. Manually run **Guardian Daily** once; confirm `https://ansible.github.io/team-devtools/` and `…/snapshot.json`
5. Disable Actions on `sathyapramod/devtools-guardian` (README deprecation PR follows there)

## Test plan
- [ ] `tox -e lint` passes
- [ ] Workflow YAML validates (Actions tab shows the four workflows after merge)
- [ ] After secrets/Pages are configured: workflow_dispatch Guardian Daily succeeds and deploys Pages
- [ ] Second Daily run loads `snapshot.json` and populates Since Last Check
- [ ] Watchdog can list `guardian-daily.yml` runs on this repo