### PR TITLE
feat(supply-chain-audit): support multi-org repos and fail fast on SAML 403

### DIFF
--- a/.agents/skills/td-supply-chain-audit/SKILL.md
+++ b/.agents/skills/td-supply-chain-audit/SKILL.md
@@ -23,7 +23,7 @@ Perform a two-phase supply chain vulnerability analysis across the Ansible DevTo
 
 ## Target Repositories
 
-All under `github.com/ansible/`:
+### ansible/
 
 1. ansible-builder
 2. ansible-compat
@@ -37,6 +37,18 @@ All under `github.com/ansible/`:
 10. tox-ansible
 11. ansible-dev-tools
 12. vscode-ansible
+13. actions
+14. ansible-content-actions
+15. mkdocs-ansible
+
+### ansible-automation-platform/
+
+16. ansible-devtools-container
+17. ansible-devspaces-container
+
+### redhat-developer/
+
+18. abbenay
 
 ## Input
 
@@ -98,7 +110,7 @@ python3 .agents/skills/td-supply-chain-audit/scripts/collect.py \
 
 This will:
 - Create the cache directory structure
-- Fetch commits, PRs, check suites, and dependency diffs for all 12 repos
+- Fetch commits, PRs, check suites, and dependency diffs for all target repos
 - Fetch all individual commits and review timelines within each merged PR
 - Fetch branch protection rules and rulesets for each repo
 - Store results as JSON in the cache directory

--- a/.agents/skills/td-supply-chain-audit/scripts/cache_utils.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/cache_utils.py
@@ -12,21 +12,57 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 TARGET_REPOS = [
-    "ansible-builder",
-    "ansible-compat",
-    "ansible-creator",
-    "ansible-dev-environment",
-    "ansible-lint",
-    "ansible-navigator",
-    "ansible-sign",
-    "molecule",
-    "pytest-ansible",
-    "tox-ansible",
-    "ansible-dev-tools",
-    "vscode-ansible",
+    "ansible/ansible-builder",
+    "ansible/ansible-compat",
+    "ansible/ansible-creator",
+    "ansible/ansible-dev-environment",
+    "ansible/ansible-lint",
+    "ansible/ansible-navigator",
+    "ansible/ansible-sign",
+    "ansible/molecule",
+    "ansible/pytest-ansible",
+    "ansible/tox-ansible",
+    "ansible/ansible-dev-tools",
+    "ansible/vscode-ansible",
+    "ansible/actions",
+    "ansible/ansible-content-actions",
+    "ansible/mkdocs-ansible",
+    "ansible-automation-platform/ansible-devtools-container",
+    "ansible-automation-platform/ansible-devspaces-container",
+    "redhat-developer/abbenay",
 ]
 
+# Default org when a bare repo name is passed (e.g. via --repos).
 GITHUB_ORG = "ansible"
+
+
+def normalize_repo(repo: str) -> str:
+    """Return a canonical ``org/repo`` slug.
+
+    Bare names (no slash) are assumed to live under ``GITHUB_ORG``.
+    """
+    if "/" in repo:
+        return repo
+    return f"{GITHUB_ORG}/{repo}"
+
+
+def repo_cache_name(repo: str) -> str:
+    """Filename-safe cache key for an ``org/repo`` slug (``org__repo``)."""
+    return normalize_repo(repo).replace("/", "__")
+
+
+def repo_from_cache_name(name: str) -> str:
+    """Inverse of :func:`repo_cache_name` (stem without ``.json``)."""
+    return name.replace("__", "/", 1)
+
+
+def repo_github_url(repo: str, *, path: str = "") -> str:
+    """Build a GitHub URL for a repo, optionally with a path suffix."""
+    slug = normalize_repo(repo)
+    base = f"https://github.com/{slug}"
+    if path:
+        return f"{base}/{path.lstrip('/')}"
+    return base
 
 
 def compute_cache_key(
@@ -139,7 +175,7 @@ def has_cached_data(cache_dir: Path, repo: str, subdir: str) -> bool:
         ``True`` if the cache file exists.
 
     """
-    path = cache_dir / subdir / f"{repo}.json"
+    path = cache_dir / subdir / f"{repo_cache_name(repo)}.json"
     return path.exists()
 
 
@@ -385,7 +421,7 @@ def get_all_cached_protection(cache_dir: Path) -> dict[str, dict[str, object]]:
         return {}
     for f in sorted(prot_dir.iterdir()):
         if f.suffix == ".json":
-            repo_name = f.stem
+            repo_name = repo_from_cache_name(f.stem)
             with f.open(encoding="utf-8") as fh:
                 protection[repo_name] = json.load(fh)
     return protection
@@ -407,7 +443,7 @@ def get_all_cached_vulns(cache_dir: Path) -> dict[str, list[dict[str, object]]]:
         return {}
     for f in sorted(vulns_dir.iterdir()):
         if f.suffix == ".json":
-            repo_name = f.stem
+            repo_name = repo_from_cache_name(f.stem)
             with f.open(encoding="utf-8") as fh:
                 data = json.load(fh)
                 if isinstance(data, list) and data:
@@ -431,7 +467,7 @@ def get_all_cached_renovate(cache_dir: Path) -> dict[str, dict[str, object]]:
         return {}
     for f in sorted(reno_dir.iterdir()):
         if f.suffix == ".json":
-            repo_name = f.stem
+            repo_name = repo_from_cache_name(f.stem)
             with f.open(encoding="utf-8") as fh:
                 configs[repo_name] = json.load(fh)
     return configs

--- a/.agents/skills/td-supply-chain-audit/scripts/collect.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/collect.py
@@ -103,6 +103,34 @@ DEP_FILE_PATTERNS = re.compile(
 )
 
 
+def _gh_api_on_failure(
+    endpoint: str,
+    result: subprocess.CompletedProcess[str],
+    *,
+    paginate: bool,
+) -> list | dict | None:
+    """Handle a non-zero ``gh api`` exit: retry rate limits, else return None."""
+    stderr_lower = result.stderr.lower()
+    # Auth / SAML / permission failures are not rate limits — fail fast.
+    if "saml" in stderr_lower or "sso" in stderr_lower:
+        print(
+            f"  ACCESS DENIED (SAML/SSO): {endpoint} — authorize the org token via gh auth refresh / SSO grant",
+            file=sys.stderr,
+        )
+    elif "rate limit" in stderr_lower or "secondary rate limit" in stderr_lower:
+        print("  Rate limited, sleeping 60s...", file=sys.stderr)
+        time.sleep(RATE_LIMIT_RETRY_SLEEP_SECONDS)
+        return gh_api(endpoint, paginate=paginate)
+    elif "404" in result.stderr or "Not Found" in result.stderr:
+        pass
+    elif "403" in result.stderr or "forbidden" in stderr_lower:
+        # Generic 403 (e.g. private repo without access) — do not retry forever.
+        print(f"  FORBIDDEN: {endpoint}: {result.stderr[:200]}", file=sys.stderr)
+    else:
+        print(f"  ERROR ({result.returncode}): {result.stderr[:200]}", file=sys.stderr)
+    return None
+
+
 def gh_api(endpoint: str, *, paginate: bool = False) -> list | dict | None:
     """Call GitHub API via gh CLI.
 
@@ -131,27 +159,7 @@ def gh_api(endpoint: str, *, paginate: bool = False) -> list | dict | None:
         return None
 
     if result.returncode != 0:
-        stderr_lower = result.stderr.lower()
-        # Auth / SAML / permission failures are not rate limits — fail fast.
-        if "saml" in stderr_lower or "sso" in stderr_lower:
-            print(
-                f"  ACCESS DENIED (SAML/SSO): {endpoint} — "
-                "authorize the org token via gh auth refresh / SSO grant",
-                file=sys.stderr,
-            )
-            return None
-        if "rate limit" in stderr_lower or "secondary rate limit" in stderr_lower:
-            print("  Rate limited, sleeping 60s...", file=sys.stderr)
-            time.sleep(RATE_LIMIT_RETRY_SLEEP_SECONDS)
-            return gh_api(endpoint, paginate=paginate)
-        if "404" in result.stderr or "Not Found" in result.stderr:
-            return None
-        # Generic 403 (e.g. private repo without access) — do not retry forever.
-        if "403" in result.stderr or "forbidden" in stderr_lower:
-            print(f"  FORBIDDEN: {endpoint}: {result.stderr[:200]}", file=sys.stderr)
-            return None
-        print(f"  ERROR ({result.returncode}): {result.stderr[:200]}", file=sys.stderr)
-        return None
+        return _gh_api_on_failure(endpoint, result, paginate=paginate)
 
     try:
         return json.loads(result.stdout)
@@ -191,9 +199,7 @@ def collect_commits(repo: str, start_date: str, end_date: str) -> list[dict]:
         Serialized commit dicts.
 
     """
-    endpoint = (
-        f"repos/{repo}/commits?since={start_date}T00:00:00Z&until={end_date}T23:59:59Z&per_page={PER_PAGE}"
-    )
+    endpoint = f"repos/{repo}/commits?since={start_date}T00:00:00Z&until={end_date}T23:59:59Z&per_page={PER_PAGE}"
     data = gh_api(endpoint, paginate=True)
     if not data or not isinstance(data, list):
         return []

--- a/.agents/skills/td-supply-chain-audit/scripts/collect.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/collect.py
@@ -28,12 +28,13 @@ try:
         PullRequest,
     )
     from cache_utils import (  # pylint: disable=import-error
-        GITHUB_ORG,
         TARGET_REPOS,
         ensure_cache_structure,
         get_cache_dir,
         has_cached_data,
+        normalize_repo,
         read_cache_file,
+        repo_cache_name,
         write_cache_file,
         write_manifest,
     )
@@ -46,12 +47,13 @@ except ImportError:
         PullRequest,
     )
     from cache_utils import (
-        GITHUB_ORG,
         TARGET_REPOS,
         ensure_cache_structure,
         get_cache_dir,
         has_cached_data,
+        normalize_repo,
         read_cache_file,
+        repo_cache_name,
         write_cache_file,
         write_manifest,
     )
@@ -129,11 +131,24 @@ def gh_api(endpoint: str, *, paginate: bool = False) -> list | dict | None:
         return None
 
     if result.returncode != 0:
-        if "rate limit" in result.stderr.lower() or "403" in result.stderr:
+        stderr_lower = result.stderr.lower()
+        # Auth / SAML / permission failures are not rate limits — fail fast.
+        if "saml" in stderr_lower or "sso" in stderr_lower:
+            print(
+                f"  ACCESS DENIED (SAML/SSO): {endpoint} — "
+                "authorize the org token via gh auth refresh / SSO grant",
+                file=sys.stderr,
+            )
+            return None
+        if "rate limit" in stderr_lower or "secondary rate limit" in stderr_lower:
             print("  Rate limited, sleeping 60s...", file=sys.stderr)
             time.sleep(RATE_LIMIT_RETRY_SLEEP_SECONDS)
             return gh_api(endpoint, paginate=paginate)
         if "404" in result.stderr or "Not Found" in result.stderr:
+            return None
+        # Generic 403 (e.g. private repo without access) — do not retry forever.
+        if "403" in result.stderr or "forbidden" in stderr_lower:
+            print(f"  FORBIDDEN: {endpoint}: {result.stderr[:200]}", file=sys.stderr)
             return None
         print(f"  ERROR ({result.returncode}): {result.stderr[:200]}", file=sys.stderr)
         return None
@@ -177,7 +192,7 @@ def collect_commits(repo: str, start_date: str, end_date: str) -> list[dict]:
 
     """
     endpoint = (
-        f"repos/{GITHUB_ORG}/{repo}/commits?since={start_date}T00:00:00Z&until={end_date}T23:59:59Z&per_page={PER_PAGE}"
+        f"repos/{repo}/commits?since={start_date}T00:00:00Z&until={end_date}T23:59:59Z&per_page={PER_PAGE}"
     )
     data = gh_api(endpoint, paginate=True)
     if not data or not isinstance(data, list):
@@ -207,7 +222,7 @@ def collect_prs_for_commits(repo: str, commits: list[dict]) -> list[dict]:
 
     for commit_data in commits:
         sha = commit_data["sha"]
-        endpoint = f"repos/{GITHUB_ORG}/{repo}/commits/{sha}/pulls"
+        endpoint = f"repos/{repo}/commits/{sha}/pulls"
         pr_list = gh_api(endpoint)
         time.sleep(RATE_LIMIT_SLEEP)
 
@@ -223,7 +238,7 @@ def collect_prs_for_commits(repo: str, commits: list[dict]) -> list[dict]:
                 continue
 
             prs_seen.add(pr_num)
-            pr_detail = gh_api(f"repos/{GITHUB_ORG}/{repo}/pulls/{pr_num}")
+            pr_detail = gh_api(f"repos/{repo}/pulls/{pr_num}")
             time.sleep(RATE_LIMIT_SLEEP)
 
             if pr_detail and isinstance(pr_detail, dict):
@@ -262,7 +277,7 @@ def collect_pr_commits_and_reviews(repo: str, prs: list[dict]) -> list[dict]:
         pr_num = pr["number"]
 
         # Get all commits on the PR branch
-        commits_endpoint = f"repos/{GITHUB_ORG}/{repo}/pulls/{pr_num}/commits?per_page=100"
+        commits_endpoint = f"repos/{repo}/pulls/{pr_num}/commits?per_page=100"
         pr_commits = gh_api(commits_endpoint)
         time.sleep(RATE_LIMIT_SLEEP)
 
@@ -270,7 +285,7 @@ def collect_pr_commits_and_reviews(repo: str, prs: list[dict]) -> list[dict]:
             pr_commits = []
 
         # Get reviews (approvals)
-        reviews_endpoint = f"repos/{GITHUB_ORG}/{repo}/pulls/{pr_num}/reviews"
+        reviews_endpoint = f"repos/{repo}/pulls/{pr_num}/reviews"
         reviews = gh_api(reviews_endpoint)
         time.sleep(RATE_LIMIT_SLEEP)
 
@@ -333,7 +348,7 @@ def collect_check_suites(repo: str, commits: list[dict]) -> dict[str, list[dict]
 
     for commit_data in commits:
         sha = commit_data["sha"]
-        endpoint = f"repos/{GITHUB_ORG}/{repo}/commits/{sha}/check-suites"
+        endpoint = f"repos/{repo}/commits/{sha}/check-suites"
         data = gh_api(endpoint)
         time.sleep(RATE_LIMIT_SLEEP)
 
@@ -453,9 +468,9 @@ def collect_renovate_config(repo: str) -> dict:
     }
 
     config_paths = [
-        f"repos/{GITHUB_ORG}/{repo}/contents/renovate.json",
-        f"repos/{GITHUB_ORG}/{repo}/contents/.github/renovate.json",
-        f"repos/{GITHUB_ORG}/{repo}/contents/renovate.json5",
+        f"repos/{repo}/contents/renovate.json",
+        f"repos/{repo}/contents/.github/renovate.json",
+        f"repos/{repo}/contents/renovate.json5",
     ]
 
     raw = _load_renovate_config_at_paths(config_paths)
@@ -539,7 +554,7 @@ def collect_dep_changes(
     first_sha = commits[-1]["sha"]
     last_sha = commits[0]["sha"]
 
-    endpoint = f"repos/{GITHUB_ORG}/{repo}/compare/{first_sha}...{last_sha}"
+    endpoint = f"repos/{repo}/compare/{first_sha}...{last_sha}"
     data = gh_api(endpoint)
 
     if not data or not isinstance(data, dict):
@@ -919,7 +934,7 @@ def collect_package_inventory(repo: str) -> list[dict]:
 
     # Check for Python lock files
     for lock_file in ["uv.lock", "poetry.lock", "pdm.lock"]:
-        endpoint = f"repos/{GITHUB_ORG}/{repo}/contents/{lock_file}"
+        endpoint = f"repos/{repo}/contents/{lock_file}"
         data = gh_api(endpoint)
         if data and isinstance(data, dict) and data.get("content"):
             try:
@@ -939,13 +954,13 @@ def collect_package_inventory(repo: str) -> list[dict]:
 
 def _collect_npm_inventory(repo: str) -> list[dict]:
     """Collect npm package inventory from lock files or package.json fallback."""
-    tree_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/trees/main")
+    tree_data = gh_api(f"repos/{repo}/git/trees/main")
     if tree_data and isinstance(tree_data, dict):
         for lock_file in ["pnpm-lock.yaml", "package-lock.json"]:
             for item in tree_data.get("tree", []):
                 if item.get("path") != lock_file or not item.get("sha"):
                     continue
-                blob_data = gh_api(f"repos/{GITHUB_ORG}/{repo}/git/blobs/{item['sha']}")
+                blob_data = gh_api(f"repos/{repo}/git/blobs/{item['sha']}")
                 if not blob_data or not isinstance(blob_data, dict):
                     continue
                 try:
@@ -956,7 +971,7 @@ def _collect_npm_inventory(repo: str) -> list[dict]:
                 return [{"name": p[0], "version": p[1], "ecosystem": "npm"} for p in parser(content)]
             time.sleep(RATE_LIMIT_SLEEP)
 
-    endpoint = f"repos/{GITHUB_ORG}/{repo}/contents/package.json"
+    endpoint = f"repos/{repo}/contents/package.json"
     data = gh_api(endpoint)
     if data and isinstance(data, dict) and data.get("content"):
         try:
@@ -1216,7 +1231,7 @@ def _collect_ruleset_required_checks(repo: str) -> list[str]:
 
     """
     required_checks: list[str] = []
-    rulesets = gh_api(f"repos/{GITHUB_ORG}/{repo}/rulesets")
+    rulesets = gh_api(f"repos/{repo}/rulesets")
     if not rulesets or not isinstance(rulesets, list):
         return required_checks
 
@@ -1226,7 +1241,7 @@ def _collect_ruleset_required_checks(repo: str) -> list[str]:
         rs_id = rs.get("id")
         if not rs_id:
             continue
-        detail = gh_api(f"repos/{GITHUB_ORG}/{repo}/rulesets/{rs_id}")
+        detail = gh_api(f"repos/{repo}/rulesets/{rs_id}")
         time.sleep(RATE_LIMIT_SLEEP)
         if not detail or not isinstance(detail, dict):
             continue
@@ -1254,7 +1269,7 @@ def collect_branch_protection(repo: str) -> dict:
         Normalized protection result dict.
 
     """
-    endpoint = f"repos/{GITHUB_ORG}/{repo}/branches/main/protection"
+    endpoint = f"repos/{repo}/branches/main/protection"
     data = gh_api(endpoint)
     if data and isinstance(data, dict) and "message" not in data:
         return _legacy_branch_protection_result(data)
@@ -1286,7 +1301,7 @@ def collect_protection_changes(repo: str, start_date: str, end_date: str) -> lis
         Protection change event dicts.
 
     """
-    endpoint = f"repos/{GITHUB_ORG}/{repo}/activity"
+    endpoint = f"repos/{repo}/activity"
     data = gh_api(endpoint, paginate=True)
     if not data or not isinstance(data, list):
         return []
@@ -1326,8 +1341,9 @@ def _load_cached_repo_counts(cache_dir: Path, repo: str) -> tuple[int, int]:
         Tuple of (commit_count, pr_count).
 
     """
-    commits = read_cache_file(cache_dir, "commits", f"{repo}.json") or []
-    prs = read_cache_file(cache_dir, "prs", f"{repo}.json") or []
+    cache_name = f"{repo_cache_name(repo)}.json"
+    commits = read_cache_file(cache_dir, "commits", cache_name) or []
+    prs = read_cache_file(cache_dir, "prs", cache_name) or []
     return len(commits), len(prs)
 
 
@@ -1445,22 +1461,23 @@ def _write_repo_cache_files(cache_dir: Path, repo: str, artifacts: dict) -> None
         artifacts: Collected artifact categories from ``_collect_repo_artifacts``.
 
     """
-    write_cache_file(cache_dir, "commits", f"{repo}.json", artifacts["commits"])
-    write_cache_file(cache_dir, "prs", f"{repo}.json", artifacts["prs"])
-    write_cache_file(cache_dir, "checks", f"{repo}.json", artifacts["checks"])
-    write_cache_file(cache_dir, "deps", f"{repo}.json", artifacts["deps"])
-    write_cache_file(cache_dir, "pr_audits", f"{repo}.json", artifacts["pr_audits"])
+    cache_name = f"{repo_cache_name(repo)}.json"
+    write_cache_file(cache_dir, "commits", cache_name, artifacts["commits"])
+    write_cache_file(cache_dir, "prs", cache_name, artifacts["prs"])
+    write_cache_file(cache_dir, "checks", cache_name, artifacts["checks"])
+    write_cache_file(cache_dir, "deps", cache_name, artifacts["deps"])
+    write_cache_file(cache_dir, "pr_audits", cache_name, artifacts["pr_audits"])
     write_cache_file(
         cache_dir,
         "renovate",
-        f"{repo}.json",
+        cache_name,
         artifacts["renovate_config"],
     )
-    write_cache_file(cache_dir, "vulns", f"{repo}.json", artifacts["vuln_results"])
+    write_cache_file(cache_dir, "vulns", cache_name, artifacts["vuln_results"])
     write_cache_file(
         cache_dir,
         "protection",
-        f"{repo}.json",
+        cache_name,
         {
             "rules": artifacts["protection"],
             "changes": artifacts["protection_changes"],
@@ -1489,8 +1506,9 @@ def collect_repo(
         Tuple of (commit_count, pr_count).
 
     """
+    repo = normalize_repo(repo)
     print(f"\n{'=' * 60}")
-    print(f"  Collecting: {GITHUB_ORG}/{repo}")
+    print(f"  Collecting: {repo}")
     print(f"{'=' * 60}")
 
     if not force and has_cached_data(cache_dir, repo, "commits"):
@@ -1547,7 +1565,7 @@ def main() -> None:
         sys.exit(1)
     print(f"Using: {gh_version}")
 
-    repos = args.repos or TARGET_REPOS
+    repos = [normalize_repo(r) for r in (args.repos or TARGET_REPOS)]
     cache_dir = get_cache_dir(args.cache_dir, args.start, args.end)
     ensure_cache_structure(cache_dir)
 

--- a/.agents/skills/td-supply-chain-audit/scripts/report.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/report.py
@@ -679,8 +679,7 @@ def generate_commit_integrity_section(commits: list[dict], findings: list[dict])
         repo_gh = repo_name if "/" in repo_name else f"ansible/{repo_name}"
         pr_str = (
             ", ".join(
-                f'<a href="https://github.com/{repo_gh}/pull/{p}" '
-                f'target="_blank" rel="noopener noreferrer">#{p}</a>'
+                f'<a href="https://github.com/{repo_gh}/pull/{p}" target="_blank" rel="noopener noreferrer">#{p}</a>'
                 for p in prs
             )
             if prs

--- a/.agents/skills/td-supply-chain-audit/scripts/report.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/report.py
@@ -254,7 +254,7 @@ def _build_repo_summary_row(  # pylint: disable=too-many-positional-arguments
 
     """
     findings_str = str(num_findings) if num_findings == 0 else (f'<span class="badge badge-high">{num_findings}</span>')
-    repo_url = f"https://github.com/ansible/{repo}"
+    repo_url = f"https://github.com/{repo}" if "/" in repo else f"https://github.com/ansible/{repo}"
     repo_link = f'<a href="{repo_url}" target="_blank" rel="noopener noreferrer">{esc(repo)}</a>'
     return (
         f"<tr>"
@@ -676,9 +676,10 @@ def generate_commit_integrity_section(commits: list[dict], findings: list[dict])
         signer = commit.get("committer_login", "")
         prs = commit.get("associated_prs", [])
         repo_name = commit.get("repo", "")
+        repo_gh = repo_name if "/" in repo_name else f"ansible/{repo_name}"
         pr_str = (
             ", ".join(
-                f'<a href="https://github.com/ansible/{repo_name}/pull/{p}" '
+                f'<a href="https://github.com/{repo_gh}/pull/{p}" '
                 f'target="_blank" rel="noopener noreferrer">#{p}</a>'
                 for p in prs
             )
@@ -773,8 +774,9 @@ def generate_dep_section(deps: list[dict], prs: list[dict]) -> str:
         pr_info = sha_to_pr.get(commit_sha)
         if pr_info:
             repo_name, pr_num = pr_info
+            repo_gh = repo_name if "/" in repo_name else f"ansible/{repo_name}"
             pr_cell = (
-                f'<a href="https://github.com/ansible/{repo_name}/pull/{pr_num}" '
+                f'<a href="https://github.com/{repo_gh}/pull/{pr_num}" '
                 f'target="_blank" rel="noopener noreferrer">#{pr_num}</a>'
             )
         else:
@@ -911,8 +913,9 @@ def generate_findings_details(findings: list[dict]) -> str:
             repo = f.get("repo", "")
             pr_link = ""
             if pr_num:
+                repo_gh = repo if "/" in repo else f"ansible/{repo}"
                 pr_link = (
-                    f' <a href="https://github.com/ansible/{repo}/pull/{pr_num}" '
+                    f' <a href="https://github.com/{repo_gh}/pull/{pr_num}" '
                     f'target="_blank" rel="noopener noreferrer">PR #{pr_num}</a>'
                 )
             summary_html = _linkify_advisory_ids(esc(f.get("summary", "")))


### PR DESCRIPTION
Add actions, content-actions, mkdocs-ansible, AAP containers, and abbenay; use org/repo slugs for API/cache paths; stop treating auth 403s as rate limits.