### PR TITLE
fix: keep Supply Chain Audit link across daily Pages deploys

### DIFF
--- a/.agents/skills/td-guardian/scripts/generate_dashboard.py
+++ b/.agents/skills/td-guardian/scripts/generate_dashboard.py
@@ -368,7 +368,7 @@ def build_health_cards(prs_data, ci_data, renovate_data, sonar_data, codecov_dat
 
         cards_html += (
             f'<a href="audit.html" target="_blank" class="security-audit-banner">'
-            f'<span class="security-audit-title">Security Audit</span>'
+            f'<span class="security-audit-title">Supply Chain Audit</span>'
             f"{badges}"
             f'<span class="security-audit-window">{esc(window)}</span>'
             f'<span class="security-audit-cta">View full report &rarr;</span>'
@@ -1393,6 +1393,8 @@ def generate_dashboard(
     ]
 
     nav_links = "".join(f'<a href="#{sid}">{label}</a>' for sid, label, html in section_list if html)
+    if security_audit_data:
+        nav_links += '<a href="audit.html" target="_blank">Supply Chain Audit</a>'
     nav_html = f'<nav class="nav-bar">{nav_links}</nav>' if nav_links else ""
 
     sections = "\n".join(html for _, _, html in section_list if html)

--- a/.github/workflows/guardian-daily.yml
+++ b/.github/workflows/guardian-daily.yml
@@ -99,6 +99,25 @@ jobs:
             rm -f "${SKILL_ROOT}/reports/previous-snapshot.json"
           fi
 
+      - name: Preserve supply-chain audit artifacts from Pages
+        run: |
+          # Daily deploys replace the whole Pages site. Re-fetch last weekly
+          # audit.html + security-audit.json so the Security Audit link survives.
+          PAGES_BASE="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          if curl -fsSL "${PAGES_BASE}/audit.html" -o "${SITE_DIR}/audit.html"; then
+            echo "Preserved audit.html from Pages"
+          else
+            echo "No audit.html on Pages yet (weekly has not published one)"
+            rm -f "${SITE_DIR}/audit.html"
+          fi
+          if curl -fsSL "${PAGES_BASE}/security-audit.json" -o "${SKILL_ROOT}/reports/security-audit.json"; then
+            echo "Loaded security-audit.json from Pages"
+            cp "${SKILL_ROOT}/reports/security-audit.json" "${SITE_DIR}/security-audit.json"
+          else
+            echo "No security-audit.json on Pages yet"
+            rm -f "${SKILL_ROOT}/reports/security-audit.json"
+          fi
+
       - name: Diff against previous snapshot
         run: |
           python3 "${SKILL_ROOT}/scripts/diff_snapshots.py" \
@@ -113,6 +132,10 @@ jobs:
 
       - name: Generate HTML dashboard
         run: |
+          EXTRA_ARGS=()
+          if [ -f "${SKILL_ROOT}/reports/security-audit.json" ]; then
+            EXTRA_ARGS+=(--security-audit "${SKILL_ROOT}/reports/security-audit.json")
+          fi
           python3 "${SKILL_ROOT}/scripts/generate_dashboard.py" \
             --prs "${SKILL_ROOT}/reports/open-prs.json" \
             --ci "${SKILL_ROOT}/reports/ci-status.json" \
@@ -121,12 +144,16 @@ jobs:
             --sonar "${SKILL_ROOT}/reports/sonar-gates.json" \
             --correlation "${SKILL_ROOT}/reports/correlation.json" \
             --changes "${SKILL_ROOT}/reports/changes.json" \
+            "${EXTRA_ARGS[@]}" \
             --output "${SITE_DIR}/index.html"
 
       - name: Publish snapshot baseline with Pages
         run: |
           cp "${SKILL_ROOT}/reports/previous-snapshot.json" "${SITE_DIR}/snapshot.json"
           cp "${SKILL_ROOT}/reports/changes.json" "${SITE_DIR}/changes.json"
+          if [ -f "${SKILL_ROOT}/reports/security-audit.json" ]; then
+            cp "${SKILL_ROOT}/reports/security-audit.json" "${SITE_DIR}/security-audit.json"
+          fi
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/guardian-weekly.yml
+++ b/.github/workflows/guardian-weekly.yml
@@ -158,6 +158,8 @@ jobs:
         run: |
           cp "${SKILL_ROOT}/reports/previous-snapshot.json" "${SITE_DIR}/snapshot.json"
           cp "${SKILL_ROOT}/reports/changes.json" "${SITE_DIR}/changes.json"
+          # Publish JSON so daily deploys can keep the Security Audit banner/link
+          cp "${SKILL_ROOT}/reports/security-audit.json" "${SITE_DIR}/security-audit.json"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
## Summary
- Daily Guardian Pages deploys were wiping `audit.html`, so [the dashboard](https://ansible.github.io/team-devtools/) lost the Supply Chain Audit link (`audit.html` 404)
- Daily now re-fetches `audit.html` + `security-audit.json` from Pages before deploy and passes `--security-audit` when available
- Weekly also publishes `security-audit.json` so daily can keep the banner/nav link
- Nav + banner label use **Supply Chain Audit**

## Test plan
- [ ] Merge, then run **Guardian Weekly** once (so `audit.html` and `security-audit.json` exist on Pages again)
- [ ] Confirm https://ansible.github.io/team-devtools/audit.html loads
- [ ] Confirm index shows Supply Chain Audit banner + nav link
- [ ] Run **Guardian Daily** and confirm `audit.html` and the link still present after deploy