### PR TITLE
ci: harden workflows for OpenSSF Scorecard alerts

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -35,7 +35,7 @@ jobs:
           ${{ toJson(github) }}
           EOF_GITHUB_CONTEXT
 
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
 
       - name: Verify PR label action
         if: github.event_name != 'merge_group'
@@ -72,7 +72,7 @@ jobs:
         # from external orgs (e.g. from ansible-automation-platform org).
         # See https://github.com/actions/add-to-project/issues/389
         continue-on-error: true
-        uses: actions/add-to-project@main
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/ansible/projects/86
           # Do not use secrets.GITHUB_TOKEN here because it does not have

--- a/.github/workflows/ah_token_refresh.yml
+++ b/.github/workflows/ah_token_refresh.yml
@@ -11,6 +11,9 @@ on:
       ah_token:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   refresh:
     runs-on: ubuntu-24.04

--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           show-progress: false
 
       # Download coverage artifacts from the test job (same workflow run)
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: logs.zip
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
       # For PRs: Extract PR number from artifact file
       - name: Fetch PR Number artifact
         if: inputs.workflow-event == 'pull_request'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pr_number
           path: .
@@ -124,7 +124,7 @@ jobs:
           echo "Running SonarCloud analysis..."
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v8
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8
         env:
           SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT }}
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,8 @@
 # push workflow is shared and expected to perform actions after a merge happens
 # on a maintenance branch (default or release). For example updating the
 # draft release-notes.
+# Permissions stay at workflow level so workflow_call consumers that only set
+# contents: read (or omit permissions) are not capped below what release-drafter needs.
 name: push
 
 permissions:

--- a/.github/workflows/push_network.yml
+++ b/.github/workflows/push_network.yml
@@ -30,18 +30,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.BOT_PAT }}
 
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.14"
 
       - name: Install antsibull-changelog, antsichaut
-        run: >
-          python3 -m pip install
-          antsibull-changelog
-          git+https://github.com/ansible-community/antsichaut.git
-          pre-commit
-          --disable-pip-version-check
+        run: |
+          set -euo pipefail
+          uv tool install antsibull-changelog
+          uv tool install pre-commit
+          uv tool install git+https://github.com/ansible-community/antsichaut.git
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run release drafter
         id: release_drafter
@@ -59,7 +59,7 @@ jobs:
 
       - name: Get previous tag
         id: previoustag
-        uses: WyriHaximus/github-action-get-previous-tag@master
+        uses: WyriHaximus/github-action-get-previous-tag@61819f33034117e6c686e6a31dba995a85afc9de # v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ name: release
 
 on:
   workflow_call:
+permissions:
+  contents: read
+
 jobs:
   release:
     name: release ${{ github.event.ref }}
@@ -14,6 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
+      contents: read
 
     env:
       FORCE_COLOR: 1
@@ -21,13 +25,16 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.14"
 
       - name: Install tox
-        run: python3 -m pip install --user "tox>=4.0.0"
+        run: |
+          set -euo pipefail
+          uv tool install --with tox-uv tox
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check out src from Git
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -35,6 +42,6 @@ jobs:
           fetch-depth: 0 # needed by setuptools-scm
 
       - name: Build dists
-        run: python3 -m tox -e pkg
+        run: tox -e pkg
       - name: Publish to pypi.org
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/.github/workflows/release_ah.yml
+++ b/.github/workflows/release_ah.yml
@@ -15,6 +15,9 @@ on:
       ah_token:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release_collection.yml
+++ b/.github/workflows/release_collection.yml
@@ -21,6 +21,9 @@ on:
       ansible_galaxy_api_key:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release_automation_hub:
     uses: ansible/team-devtools/.github/workflows/release_ah.yml@main

--- a/.github/workflows/release_galaxy.yml
+++ b/.github/workflows/release_galaxy.yml
@@ -15,6 +15,9 @@ on:
       ansible_galaxy_api_key:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,19 @@ on:
         default: "false"
   schedule:
     - cron: "0 0 * * *"
+
 permissions:
-  contents: write
-  id-token: write
-  packages: write
-  pull-requests: write
-  checks: write
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-24.04
     environment:
       name: ack # BOT_PAT
       deployment: false
+    permissions:
+      contents: write # commit & push lint autofixes
+      pull-requests: write # comment on unfixed lint errors
     steps:
       - name: Dump event information
         run: |
@@ -42,15 +43,15 @@ jobs:
           echo "github.event.action: ${{ github.event.action }}"
           echo "github.event.inputs: ${{ github.event.inputs }}"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           token: ${{ secrets.BOT_PAT }}
 
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
-      - uses: j178/prek-action@v2
+      - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
         id: prek
         with:
           extra-args: --config .pre-commit-config.yaml --all-files
@@ -88,6 +89,12 @@ jobs:
   test:
     needs:
       - lint
+    permissions:
+      checks: read
+      contents: read
+      id-token: write
+      packages: write # some tox environments might produce containers
+      pull-requests: write # allow commenting on unsigned commits
     # tests reusable tox workflow
     uses: ./.github/workflows/tox.yml
     with:
@@ -113,10 +120,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
   push:
     if: github.event_name == 'push'
+    permissions:
+      contents: write
+      pull-requests: read
     uses: ./.github/workflows/push.yml
     secrets: inherit

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -79,13 +79,16 @@ on:
         description: Paths to log files to upload as artifacts.
         required: false
         type: string
-# keep permissions at top level because this is a composite workflow
+# Keep permissions at top level for reusable workflow_call consumers.
+# Callers often set workflow-level contents: read only; job-scoped elevation
+# here would be capped by the caller and break artifact upload / OIDC / PR comments.
+# See OpenSSF Scorecard Token-Permissions follow-up: update callers first, then tighten.
 permissions:
   checks: read
   contents: read
   id-token: write
   packages: write # some tox environments might produce containers
-  pull-requests: write # allow codenotify to comment on pull-request
+  pull-requests: write # allow commenting on unsigned commits / codenotify
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # might be needed by tox commands
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -125,7 +128,7 @@ jobs:
 
       - name: Determine matrix
         id: generate_matrix
-        uses: ansible/actions/matrix@main
+        uses: ansible/actions/matrix@a4a333cdfd95bfe9dae231fc5c7fca6d3008f2c2 # main
         with:
           min_python: ${{ inputs.min_python }}
           max_python: ${{ inputs.max_python }}
@@ -165,7 +168,7 @@ jobs:
           key: prek-${{ matrix.name }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.uv_python_version || '3.12' }}
 
@@ -243,7 +246,7 @@ jobs:
 
       - name: Archive logs and coverage data
         if: always()
-        uses: ansible/actions/upload-artifact@main
+        uses: ansible/actions/upload-artifact@a4a333cdfd95bfe9dae231fc5c7fca6d3008f2c2 # main
         with:
           name: logs-${{ matrix.name }}.zip
           include-hidden-files: true
@@ -308,7 +311,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Save PR number
         if: github.event_name == 'pull_request'
@@ -337,7 +340,7 @@ jobs:
 
       - name: Decide whether the needed jobs succeeded or failed
         id: alls-green
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
 


### PR DESCRIPTION
## Summary
- Clear OpenSSF Scorecard code-scanning findings for unpinned Actions, missing/overbroad token permissions (where safe), and unpinned `pip` installs.
- Keep reusable `workflow_call` permission contracts compatible with existing portfolio callers (e.g. ansible-navigator `contents: read` wrappers).

## Changes
- Pin third-party and floating Actions to commit SHAs (`setup-uv`, `prek-action`, `alls-green`, `pypi-publish`, `add-to-project`, `sonarqube-scan-action`, `download-artifact`, `WyriHaximus/get-previous-tag`, `ansible/actions/*`, etc.).
- `test.yml`: default `contents: read`; elevate write scopes on `lint` / `test` / `push` jobs only.
- `release_*` / `ah_token_refresh.yml`: declare top-level `contents: read`.
- `release.yml` / `push_network.yml`: replace unpinned `pip install` with `uv tool install` and put `~/.local/bin` on `PATH`.
- `tox.yml` / `push.yml`: document why write scopes remain at workflow level for reusable consumers (caller caps job-level elevation).

## Quality of life
- Workflow comments document the reusable-workflow permission inheritance trap and the planned follow-up (tighten after callers grant matching job `permissions`).

## Test plan
- [x] `tox -e lint` passes
- [ ] `tox -e py` — 6 pre-existing failures on `main` for `pycontribs/subprocess-tee` label create (HTTP 404); unrelated to this PR
- [ ] CI green on this PR (`test` → tox matrix, artifact merge, lint)
- [ ] Scorecard / code-scanning: Pinned-Dependencies and Token-Permissions improve after next scorecard run (nested `release_collection.yml@main` refs intentionally remain)

## Out of scope / follow-ups
- Fleet update so callers of `tox.yml` / `push.yml` / `ack.yml` set job-level permissions, then tighten reusable workflows to Scorecard job-scoped writes
- `finalize.yml` still uses `permissions: read-all`
- Branch protection / CII Best Practices / Fuzzing Scorecard checks (repo settings / process)
