### PR TITLE
ci: tighten Scorecard Token-Permissions and pin release workflows

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -13,6 +13,10 @@ on:
     secrets:
       BOT_PAT:
         required: false
+
+permissions:
+  contents: read
+
 jobs:
   ack:
     runs-on: ubuntu-24.04

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,13 +2,11 @@
 # push workflow is shared and expected to perform actions after a merge happens
 # on a maintenance branch (default or release). For example updating the
 # draft release-notes.
-# Permissions stay at workflow level so workflow_call consumers that only set
-# contents: read (or omit permissions) are not capped below what release-drafter needs.
+# Callers must grant contents: write on the calling job for release-drafter.
 name: push
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 on:
   workflow_call: # allows reuse of this workflow from other devtools repos
@@ -16,6 +14,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # release-drafter updates draft releases
+      pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7
         env:

--- a/.github/workflows/push_network.yml
+++ b/.github/workflows/push_network.yml
@@ -19,10 +19,16 @@ on:
         description: Bot secret
         required: true
 
+# Callers that cap GITHUB_TOKEN must grant contents: write on the calling job.
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-24.04
     environment: push
+    permissions:
+      contents: write # release-drafter updates draft releases
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/release_collection.yml
+++ b/.github/workflows/release_collection.yml
@@ -26,14 +26,16 @@ permissions:
 
 jobs:
   release_automation_hub:
-    uses: ansible/team-devtools/.github/workflows/release_ah.yml@main
+    # Pin by SHA for OpenSSF Scorecard Pinned-Dependencies (cross-repo callers need owner/repo@ref).
+    uses: ansible/team-devtools/.github/workflows/release_ah.yml@6446fb695ce7a3d181a85cb24ff9349bdcec8e08 # main
     with:
       environment: release
     secrets:
       ah_token: ${{ secrets.ah_token }}
 
   release_galaxy:
-    uses: ansible/team-devtools/.github/workflows/release_galaxy.yml@main
+    # Keep in sync with release_automation_hub pin when release_galaxy.yml changes.
+    uses: ansible/team-devtools/.github/workflows/release_galaxy.yml@6446fb695ce7a3d181a85cb24ff9349bdcec8e08 # main
     needs: [release_automation_hub]
     with:
       environment: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       name: ack # BOT_PAT
       deployment: false
     permissions:
-      contents: write # commit & push lint autofixes
+      # git commit/push use BOT_PAT from checkout; GITHUB_TOKEN only comments
       pull-requests: write # comment on unfixed lint errors
     steps:
       - name: Dump event information

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -79,16 +79,11 @@ on:
         description: Paths to log files to upload as artifacts.
         required: false
         type: string
-# Keep permissions at top level for reusable workflow_call consumers.
-# Callers often set workflow-level contents: read only; job-scoped elevation
-# here would be capped by the caller and break artifact upload / OIDC / PR comments.
-# See OpenSSF Scorecard Token-Permissions follow-up: update callers first, then tighten.
+# Top-level read-only for OpenSSF Scorecard Token-Permissions; writes are job-scoped.
+# If the caller caps GITHUB_TOKEN (e.g. workflow contents: read), the calling job must
+# grant any write scopes this workflow needs — called workflows cannot expand the token.
 permissions:
-  checks: read
   contents: read
-  id-token: write
-  packages: write # some tox environments might produce containers
-  pull-requests: write # allow commenting on unsigned commits / codenotify
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # might be needed by tox commands
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,6 +97,9 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
       deployment: false
+    permissions:
+      contents: read
+      pull-requests: write # comment when commits lack verified signatures
     outputs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
@@ -145,6 +143,10 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
       deployment: false
+    permissions:
+      contents: read
+      id-token: write # codecov OIDC
+      packages: write # some tox environments might produce containers
     needs:
       - prepare
     defaults:
@@ -303,6 +305,9 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
       deployment: false
+    permissions:
+      contents: read
+      checks: read
     needs:
       - test
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Close remaining OpenSSF Scorecard Token-Permissions findings by keeping workflow defaults read-only and scoping write permissions to jobs.
- Pin nested `release_ah` / `release_galaxy` workflows by SHA so Pinned-Dependencies no longer flags `@main`.
- Drop unnecessary `contents: write` from the lint job (`BOT_PAT` already owns git push).

## Changes
- `tox.yml` / `push.yml`: top-level `contents: read`; elevate writes per job
- `ack.yml` / `push_network.yml`: add missing top-level `contents: read`
- `test.yml`: lint job keeps `pull-requests: write` only
- `release_collection.yml`: pin nested reusable workflows to `6446fb6` (bump when those files change)

## Quality of life
- Clarifies reusable-workflow caller contract in comments: if a caller caps `GITHUB_TOKEN`, the calling job must grant needed write scopes (called workflows cannot expand the token).

## Test plan
- [x] `tox -e lint` passes
- [x] `CI=1 tox -e py` passes
- [ ] Scorecard / code scanning re-run clears Token-Permissions top-level findings and Pinned-Dependencies on `release_collection.yml`
- [ ] Confirm team-devtools `test` workflow: lint autofix (BOT_PAT), tox OIDC, push release-drafter
- [ ] Follow-up: callers that set workflow `contents: read` without job elevation (e.g. ansible-navigator `push.yml`) need explicit `contents: write` on the `uses:` job — pre-existing under GitHub’s reusable-workflow ceiling, not a regression from moving writes to job level


Made with [Cursor](https://cursor.com)