### PR TITLE
chore(skills): fail-fast test helpers in pr-new/pr-review

### DIFF
--- a/.agents/skills/td-pr-new/SKILL.md
+++ b/.agents/skills/td-pr-new/SKILL.md
@@ -109,7 +109,11 @@ module** surrounding each changed hunk — not just the hunk itself.
    function, construct one realistic failure case: an edge-case input,
    an empty-but-not-falsy value, a timeout, a concurrent access. Trace
    it through the code path. If it fails silently or violates the
-   declared type, that's a finding.
+   declared type, that's a finding. Also inspect **test helpers**:
+   allocation/probe helpers that silently return sentinel values
+   (port `0`, empty host, `-1`) instead of failing hide infrastructure
+   errors and cause confusing flakes — prefer fail-fast with an
+   `error` path and a clear rejection when the result is unusable.
 
 9. **Do inherited contracts hold?** When implementing a Protocol or
    extending a base class, check that the subclass honors the full

--- a/.agents/skills/td-pr-review/SKILL.md
+++ b/.agents/skills/td-pr-review/SKILL.md
@@ -164,7 +164,10 @@ scenarios for public functions: what happens with an empty-but-not-falsy
 value, a field combination after partial deletion, a response that
 satisfies the HTTP status check but lacks expected fields? If the traced
 path fails silently, sends a vacuous request, or produces a return value
-that violates the declared type, the reviewer flags it.
+that violates the declared type, the reviewer flags it. The same lens
+applies to **test helpers**: probes that silently return sentinel values
+(e.g. port `0`) instead of failing hide setup errors and produce
+confusing flakes — fail-fast with an error handler is required.
 
 **Inherited contract completeness.** When the diff extends a class or
 implements a Protocol, the reviewer checks that the subclass honors the


### PR DESCRIPTION
## Summary

- Strengthen `td-pr-new` Step 3 Q8 and `td-pr-review` adversarial-input tracing: test helpers that silently return sentinel values (port `0`, empty host) instead of failing hide infrastructure errors and cause confusing flakes.
- Context: Copilot on [redhat-developer/abbenay#89](https://github.com/redhat-developer/abbenay/pull/89) flagged an ephemeral-port probe that fell back to `0` without an `error` handler.

## Test plan

- [ ] Skill text reads clearly in review
- [ ] No other skill files changed