### PR TITLE
fix(guardian): reduce vulnerability noise with dedup and affected-range checks

### DIFF
--- a/.agents/skills/td-guardian/scripts/convert_audit.py
+++ b/.agents/skills/td-guardian/scripts/convert_audit.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Convert supply-chain audit cache into a single JSON for the Guardian dashboard.
+
+Reads findings.json, findings_summary.json, and recommendations.json from
+an audit cache directory and outputs a combined JSON object.
+
+Usage:
+    python3 scripts/convert_audit.py --cache-dir .supply-chain-audit/cache/<hash> \
+        -o reports/security-audit.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+CATEGORY_LABELS = {
+    "unsigned_commit": "Unsigned Commits",
+    "github_web_signed": "GitHub-Web-Signed Commits",
+    "orphan_commit": "Orphan Commits (No PR)",
+    "bypassed_ci": "Bypassed CI",
+    "post_merge_push": "Post-Merge Pushes",
+    "replicated_message": "Replicated Commit Messages",
+    "suspicious_dep_timing": "Suspicious Dependency Timing",
+    "yanked_version": "Yanked/Deleted Versions",
+    "protection_changed": "Branch Protection Changes",
+    "post_approval_commit": "Post-Approval Commits",
+    "bot_only_approval": "Bot-Only Approvals",
+    "cooldown_violated": "Renovate Cooldown Violations",
+    "known_vulnerability": "Known Vulnerabilities (OSV.dev)",
+    "self_approved": "Self-Approved PRs",
+}
+
+
+def load_json(path: Path) -> dict | list | None:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"WARN: Could not load {path}: {e}", file=sys.stderr)
+        return None
+
+
+def _group_vuln_findings(findings: list[dict]) -> list[dict]:
+    """Group vulnerability findings by (package, vuln_id) across repos.
+
+    Non-vulnerability findings are passed through unchanged.
+    Vulnerability findings are collapsed: one entry per unique
+    (package, vuln_id) with a ``repos`` list showing which repos
+    are affected.
+    """
+    grouped = []
+    vuln_map: dict[tuple[str, str], dict] = {}
+
+    for f in findings:
+        category = f.get("category", "")
+        if category != "known_vulnerability":
+            grouped.append(f)
+            continue
+
+        evidence = f.get("evidence", {})
+        pkg = evidence.get("package", "")
+        vuln_id = evidence.get("vuln_id", "")
+        if not pkg or not vuln_id:
+            grouped.append(f)
+            continue
+
+        key = (pkg.lower(), vuln_id)
+
+        if key not in vuln_map:
+            entry = dict(f)
+            entry["repos"] = [f.get("repo", "")]
+            vuln_map[key] = entry
+        else:
+            repo = f.get("repo", "")
+            if repo not in vuln_map[key]["repos"]:
+                vuln_map[key]["repos"].append(repo)
+
+    grouped.extend(vuln_map.values())
+    return grouped
+
+
+def convert(cache_dir: str) -> dict:
+    base = Path(cache_dir)
+
+    summary = load_json(base / "findings_summary.json")
+    findings = load_json(base / "findings.json")
+    recommendations = load_json(base / "recommendations.json")
+
+    if not summary:
+        print("ERROR: findings_summary.json is required", file=sys.stderr)
+        sys.exit(1)
+
+    raw_findings: list[dict] = findings if isinstance(findings, list) else []
+    findings_grouped = _group_vuln_findings(raw_findings)
+
+    vuln_count_raw = sum(
+        1 for f in raw_findings
+        if f.get("category", f.get("type", "")) in ("vulnerability", "known_vulnerability")
+    )
+    vuln_count_grouped = sum(
+        1 for f in findings_grouped
+        if f.get("category", f.get("type", "")) in ("vulnerability", "known_vulnerability")
+    )
+    if vuln_count_raw != vuln_count_grouped:
+        print(
+            f"  Dedup: {vuln_count_raw} vulnerability findings -> {vuln_count_grouped} unique",
+            file=sys.stderr,
+        )
+
+    return {
+        "audit_window": summary.get("audit_window", ""),
+        "repos_audited": summary.get("repos_audited", []),
+        "total_findings": summary.get("total_findings", 0),
+        "total_findings_deduped": len(findings_grouped),
+        "risk_totals": summary.get("risk_totals", {}),
+        "category_breakdown": summary.get("category_breakdown", []),
+        "repo_breakdown": summary.get("repo_breakdown", []),
+        "findings": raw_findings,
+        "findings_grouped": findings_grouped,
+        "recommendations": recommendations or [],
+        "category_labels": CATEGORY_LABELS,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert audit cache to Guardian dashboard JSON",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        required=True,
+        help="Path to audit cache directory containing findings*.json",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output file (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    data = convert(args.cache_dir)
+
+    output = json.dumps(data, indent=2)
+    if args.output:
+        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/td-guardian/scripts/fetch_supply_chain.py
+++ b/.agents/skills/td-guardian/scripts/fetch_supply_chain.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""Fetch supply-chain audit data for the Guardian dashboard.
+
+Collects three categories of findings from the GitHub API and OSV.dev:
+  1. Post-approval commits — code pushed after PR was approved
+  2. Bot-only approvals — PRs merged without human review
+  3. Known vulnerabilities — packages with CVEs (via OSV.dev)
+
+Output: JSON suitable for --supply-chain flag in generate_dashboard.py
+
+Usage:
+    python3 scripts/fetch_supply_chain.py --repos-file config/repos.json > reports/supply-chain.json
+    python3 scripts/fetch_supply_chain.py --repos-file config/repos.json --days 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+GH_TOKEN = os.environ.get("GH_TOKEN", "")
+BOT_ACCOUNTS = {
+    "ansibuddy",
+    "dependabot[bot]",
+    "renovate[bot]",
+    "github-actions[bot]",
+    "pre-commit-ci[bot]",
+    "codecov[bot]",
+    "mergify[bot]",
+}
+
+OSV_API = "https://api.osv.dev/v1/query"
+LOCK_FILES = {
+    "requirements.txt",
+    "constraints.txt",
+    "uv.lock",
+    "pnpm-lock.yaml",
+    "package-lock.json",
+    "yarn.lock",
+}
+DEP_FILES = {"pyproject.toml", "setup.cfg", "package.json"}
+
+
+def _is_bot(login: str) -> bool:
+    return login in BOT_ACCOUNTS or login.endswith("[bot]")
+
+
+def gh_api(endpoint: str, per_page: int = 100) -> Any:
+    """Call GitHub REST API with pagination support."""
+    results = []
+    url = f"https://api.github.com/{endpoint}"
+    separator = "&" if "?" in url else "?"
+    url += f"{separator}per_page={per_page}"
+
+    while url:
+        req = Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        if GH_TOKEN:
+            req.add_header("Authorization", f"Bearer {GH_TOKEN}")
+
+        try:
+            with urlopen(req, timeout=30) as resp:
+                data = json.loads(resp.read())
+                if isinstance(data, list):
+                    results.extend(data)
+                else:
+                    return data
+
+                link = resp.headers.get("Link", "")
+                url = ""
+                for part in link.split(","):
+                    if 'rel="next"' in part:
+                        url = part.split("<")[1].split(">")[0]
+                        break
+        except (HTTPError, URLError) as e:
+            print(f"  WARN: GitHub API error for {endpoint}: {e}", file=sys.stderr)
+            return results or []
+
+    return results
+
+
+def gh_graphql(query: str, variables: dict | None = None) -> dict:
+    """Call GitHub GraphQL API."""
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = Request("https://api.github.com/graphql", data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    if GH_TOKEN:
+        req.add_header("Authorization", f"Bearer {GH_TOKEN}")
+
+    try:
+        with urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except (HTTPError, URLError) as e:
+        print(f"  WARN: GraphQL error: {e}", file=sys.stderr)
+        return {}
+
+
+def fetch_merged_prs(owner: str, repo: str, since: str) -> list[dict]:
+    """Fetch recently merged PRs."""
+    query = f"repo:{owner}/{repo} is:pr is:merged merged:>={since}"
+    encoded_query = quote(query, safe="")
+    data = gh_api(f"search/issues?q={encoded_query}&sort=updated&order=desc")
+    if isinstance(data, dict):
+        return data.get("items", [])
+    return []
+
+
+def fetch_pr_reviews(owner: str, repo: str, pr_number: int) -> list[dict]:
+    """Fetch reviews for a PR."""
+    return gh_api(f"repos/{owner}/{repo}/pulls/{pr_number}/reviews")
+
+
+def fetch_pr_commits(owner: str, repo: str, pr_number: int) -> list[dict]:
+    """Fetch commits in a PR."""
+    return gh_api(f"repos/{owner}/{repo}/pulls/{pr_number}/commits")
+
+
+def detect_post_approval_commits(
+    owner: str,
+    repo: str,
+    pr: dict,
+    reviews: list[dict],
+    commits: list[dict],
+) -> dict | None:
+    """Check if commits were pushed after the last approval."""
+    approvals = [r for r in reviews if r.get("state") == "APPROVED" and r.get("submitted_at")]
+    if not approvals:
+        return None
+
+    last_approval_time = max(a["submitted_at"] for a in approvals)
+    last_approver = next(
+        (a["user"]["login"] for a in approvals if a["submitted_at"] == last_approval_time),
+        "unknown",
+    )
+
+    post_approval = []
+    for c in commits:
+        commit_date = c.get("commit", {}).get("committer", {}).get("date", "")
+        if commit_date > last_approval_time:
+            post_approval.append(c)
+
+    if not post_approval:
+        return None
+
+    pr_author = pr.get("user", {}).get("login", "unknown")
+    approver_logins = {a["user"]["login"] for a in approvals}
+
+    from_third_party = [
+        c
+        for c in post_approval
+        if c.get("author", {}).get("login", "") != pr_author
+        and c.get("author", {}).get("login", "") not in approver_logins
+    ]
+
+    if from_third_party:
+        risk = "critical"
+    elif all(c.get("author", {}).get("login", "") == pr_author for c in post_approval):
+        risk = "high"
+    else:
+        risk = "medium"
+
+    return {
+        "category": "post_approval_commit",
+        "risk": risk,
+        "repo": f"{owner}/{repo}",
+        "pr_number": pr["number"],
+        "pr_title": pr.get("title", ""),
+        "pr_url": pr.get("html_url", pr.get("pull_request", {}).get("html_url", "")),
+        "pr_author": pr_author,
+        "last_approver": last_approver,
+        "last_approval_time": last_approval_time,
+        "post_approval_count": len(post_approval),
+        "commits": [
+            {
+                "sha": c["sha"][:8],
+                "author": c.get("author", {}).get("login", "unknown"),
+                "message": c.get("commit", {}).get("message", "").split("\n")[0][:80],
+                "date": c.get("commit", {}).get("committer", {}).get("date", ""),
+            }
+            for c in post_approval[:5]
+        ],
+    }
+
+
+def detect_bot_only_approval(
+    owner: str,
+    repo: str,
+    pr: dict,
+    reviews: list[dict],
+) -> dict | None:
+    """Check if a PR was merged with only bot approvals."""
+    approvals = [r for r in reviews if r.get("state") == "APPROVED"]
+    if not approvals:
+        return None
+
+    human_approvals = [a for a in approvals if not _is_bot(a.get("user", {}).get("login", ""))]
+    bot_approvals = [a for a in approvals if _is_bot(a.get("user", {}).get("login", ""))]
+
+    if human_approvals:
+        return None
+
+    if not bot_approvals:
+        return None
+
+    pr_author = pr.get("user", {}).get("login", "unknown")
+    pr_title = pr.get("title", "")
+    bot_names = list({a["user"]["login"] for a in bot_approvals})
+
+    is_bot_pr = _is_bot(pr_author)
+    is_dep_only = any(kw in pr_title.lower() for kw in ("chore(deps)", "bump ", "update dependency", "lock file"))
+
+    if is_bot_pr and is_dep_only:
+        risk = "low"
+    elif is_bot_pr:
+        risk = "medium"
+    else:
+        risk = "high"
+
+    return {
+        "category": "bot_only_approval",
+        "risk": risk,
+        "repo": f"{owner}/{repo}",
+        "pr_number": pr["number"],
+        "pr_title": pr_title,
+        "pr_url": pr.get("html_url", pr.get("pull_request", {}).get("html_url", "")),
+        "pr_author": pr_author,
+        "bot_approvers": bot_names,
+        "is_bot_pr": is_bot_pr,
+        "is_dep_only": is_dep_only,
+        "merged_at": pr.get("pull_request", {}).get("merged_at", ""),
+    }
+
+
+def fetch_dependency_versions(owner: str, repo: str) -> list[dict]:
+    """Extract package versions from lock/dep files on default branch."""
+    packages = []
+
+    tree = gh_api(f"repos/{owner}/{repo}/git/trees/HEAD?recursive=1")
+    if isinstance(tree, dict):
+        for item in tree.get("tree", []):
+            path = item.get("path", "")
+            filename = path.split("/")[-1] if "/" in path else path
+            if filename not in LOCK_FILES and filename not in DEP_FILES:
+                continue
+            if filename == "pyproject.toml":
+                packages.extend(_parse_pyproject(owner, repo, path))
+            elif filename == "package.json":
+                packages.extend(_parse_package_json(owner, repo, path))
+
+    return packages
+
+
+def _parse_pyproject(owner: str, repo: str, path: str) -> list[dict]:
+    """Parse dependencies from pyproject.toml (simple regex approach)."""
+    import re
+
+    try:
+        content_data = gh_api(f"repos/{owner}/{repo}/contents/{path}")
+        if isinstance(content_data, dict) and content_data.get("encoding") == "base64":
+            import base64
+
+            content = base64.b64decode(content_data["content"]).decode()
+        else:
+            return []
+    except Exception:
+        return []
+
+    packages = []
+    dep_pattern = re.compile(r'"([a-zA-Z0-9_-]+)\s*([><=!~]+\s*[\d.]+(?:\.\*)?)"')
+    for match in dep_pattern.finditer(content):
+        name = match.group(1)
+        version_spec = match.group(2).strip()
+        version = re.search(r"[\d.]+", version_spec)
+        if version:
+            packages.append(
+                {
+                    "name": name,
+                    "version": version.group(),
+                    "ecosystem": "PyPI",
+                },
+            )
+
+    return packages
+
+
+def _parse_package_json(owner: str, repo: str, path: str) -> list[dict]:
+    """Parse dependencies from package.json."""
+    try:
+        content_data = gh_api(f"repos/{owner}/{repo}/contents/{path}")
+        if isinstance(content_data, dict) and content_data.get("encoding") == "base64":
+            import base64
+
+            content = base64.b64decode(content_data["content"]).decode()
+            pkg = json.loads(content)
+        else:
+            return []
+    except Exception:
+        return []
+
+    packages = []
+    for section in ("dependencies", "devDependencies"):
+        for name, version_spec in pkg.get(section, {}).items():
+            version = version_spec.lstrip("^~>=<! ")
+            if version and version[0].isdigit():
+                packages.append(
+                    {
+                        "name": name,
+                        "version": version,
+                        "ecosystem": "npm",
+                    },
+                )
+
+    return packages
+
+
+def query_osv(package: str, version: str, ecosystem: str) -> list[dict]:
+    """Query OSV.dev for known vulnerabilities."""
+    payload = json.dumps(
+        {
+            "version": version,
+            "package": {"name": package, "ecosystem": ecosystem},
+        },
+    ).encode()
+
+    req = Request(OSV_API, data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+
+    try:
+        with urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            return data.get("vulns", [])
+    except (HTTPError, URLError):
+        return []
+
+
+def _map_severity(severity_data: Any) -> str:
+    """Map OSV severity to 4 levels: critical, high, medium, low."""
+    s = str(severity_data).upper()
+    if "CRITICAL" in s:
+        return "critical"
+    if "HIGH" in s:
+        return "high"
+    if "MODERATE" in s or "MEDIUM" in s:
+        return "medium"
+    if "LOW" in s:
+        return "low"
+    # Try parsing a CVSS score (e.g. "CVSS:3.1/AV:N/.../S:U" or a bare float)
+    import re
+    score_match = re.search(r"(\d+\.\d+)", s)
+    if score_match:
+        score = float(score_match.group(1))
+        if score >= 9.0:
+            return "critical"
+        if score >= 7.0:
+            return "high"
+        if score >= 4.0:
+            return "medium"
+        return "low"
+    return "medium"
+
+
+def _version_in_affected_ranges(version: str, affected_list: list[dict], pkg_name: str, ecosystem: str) -> bool:
+    """Check if a version falls within any affected range from OSV data."""
+    from packaging.version import Version, InvalidVersion
+
+    for affected in affected_list:
+        apkg = affected.get("package", {})
+        if apkg.get("name", "").lower() != pkg_name.lower():
+            continue
+        if apkg.get("ecosystem", "") != ecosystem:
+            continue
+        for rng in affected.get("ranges", []):
+            if rng.get("type") != "ECOSYSTEM":
+                continue
+            introduced = None
+            fixed = None
+            for event in rng.get("events", []):
+                if "introduced" in event:
+                    introduced = event["introduced"]
+                if "fixed" in event:
+                    fixed = event["fixed"]
+            if introduced is None:
+                continue
+            try:
+                v = Version(version)
+                intro_v = Version(introduced) if introduced != "0" else Version("0")
+                if v < intro_v:
+                    continue
+                if fixed:
+                    if v >= Version(fixed):
+                        continue
+                return True
+            except InvalidVersion:
+                return True
+    return False
+
+
+def detect_vulnerabilities(owner: str, repo: str, packages: list[dict]) -> list[dict]:
+    """Scan packages against OSV.dev for known CVEs."""
+    findings = []
+    seen = set()
+
+    unique_packages = {}
+    for pkg in packages:
+        key = (pkg["name"].lower(), pkg["version"], pkg["ecosystem"])
+        if key not in unique_packages:
+            unique_packages[key] = pkg
+
+    for pkg in unique_packages.values():
+        vulns = query_osv(pkg["name"], pkg["version"], pkg["ecosystem"])
+        if not vulns:
+            continue
+
+        for vuln in vulns:
+            vuln_id = vuln.get("id", "unknown")
+
+            dedup_key = (pkg["name"].lower(), pkg["version"], vuln_id)
+            if dedup_key in seen:
+                continue
+            seen.add(dedup_key)
+
+            affected = vuln.get("affected", [])
+            if affected and not _version_in_affected_ranges(
+                pkg["version"], affected, pkg["name"], pkg["ecosystem"]
+            ):
+                continue
+
+            aliases = vuln.get("aliases", [])
+            severity_data = vuln.get("database_specific", {}).get("severity", "")
+            if not severity_data:
+                severities = vuln.get("severity", [])
+                if severities:
+                    severity_data = severities[0].get("score", "unknown")
+
+            summary_text = vuln.get("summary", "No description available")
+
+            cve_ids = [a for a in aliases if a.startswith("CVE-")]
+            risk = _map_severity(severity_data)
+
+            findings.append(
+                {
+                    "category": "vulnerability",
+                    "risk": risk,
+                    "repo": f"{owner}/{repo}",
+                    "package": pkg["name"],
+                    "version": pkg["version"],
+                    "ecosystem": pkg["ecosystem"],
+                    "vuln_id": vuln_id,
+                    "cve_ids": cve_ids,
+                    "summary": summary_text[:200],
+                    "aliases": aliases,
+                },
+            )
+
+    return findings
+
+
+def process_repo(owner: str, repo: str, since: str, scan_vulns: bool = True) -> dict:
+    """Process a single repo for all three finding categories."""
+    print(f"  Scanning {owner}/{repo}...", file=sys.stderr)
+
+    post_approval_findings = []
+    bot_only_findings = []
+    vuln_findings = []
+
+    # Fetch merged PRs
+    merged_prs = fetch_merged_prs(owner, repo, since)
+    print(f"    {len(merged_prs)} merged PRs since {since}", file=sys.stderr)
+
+    for pr in merged_prs:
+        pr_number = pr["number"]
+        time.sleep(0.5)  # rate limit
+
+        reviews = fetch_pr_reviews(owner, repo, pr_number)
+        commits = fetch_pr_commits(owner, repo, pr_number)
+
+        # Post-approval check
+        finding = detect_post_approval_commits(owner, repo, pr, reviews, commits)
+        if finding:
+            post_approval_findings.append(finding)
+
+        # Bot-only approval check
+        finding = detect_bot_only_approval(owner, repo, pr, reviews)
+        if finding:
+            bot_only_findings.append(finding)
+
+    # Vulnerability scan
+    if scan_vulns:
+        print("    Scanning dependencies for vulnerabilities...", file=sys.stderr)
+        packages = fetch_dependency_versions(owner, repo)
+        if packages:
+            vuln_findings = detect_vulnerabilities(owner, repo, packages[:50])
+            print(f"    {len(packages)} packages, {len(vuln_findings)} vulnerabilities found", file=sys.stderr)
+
+    return {
+        "owner": owner,
+        "repo": repo,
+        "post_approval": post_approval_findings,
+        "bot_only": bot_only_findings,
+        "vulnerabilities": vuln_findings,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch supply-chain audit data")
+    parser.add_argument("--repos-file", required=True, help="Path to repos.json config")
+    parser.add_argument("--days", type=int, default=7, help="Look back N days for merged PRs (default: 7)")
+    parser.add_argument("--skip-vulns", action="store_true", help="Skip vulnerability scanning (faster)")
+    parser.add_argument("--output", "-o", help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    with open(args.repos_file) as f:
+        config = json.load(f)
+
+    repos = config.get("repos", [])
+    since = (datetime.now(UTC) - timedelta(days=args.days)).strftime("%Y-%m-%d")
+
+    print(f"Supply-chain audit: {len(repos)} repos, since {since}", file=sys.stderr)
+
+    results = []
+    total_post_approval = 0
+    total_bot_only = 0
+    total_vulns = 0
+
+    for repo_conf in repos:
+        owner = repo_conf["owner"]
+        repo = repo_conf["repo"]
+        result = process_repo(owner, repo, since, scan_vulns=not args.skip_vulns)
+        results.append(result)
+        total_post_approval += len(result["post_approval"])
+        total_bot_only += len(result["bot_only"])
+        total_vulns += len(result["vulnerabilities"])
+
+    output = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "since": since,
+        "days": args.days,
+        "aggregate": {
+            "total_post_approval": total_post_approval,
+            "total_bot_only": total_bot_only,
+            "total_vulnerabilities": total_vulns,
+            "repos_scanned": len(repos),
+            "critical_findings": sum(
+                1
+                for r in results
+                for f in r["post_approval"] + r["bot_only"] + r["vulnerabilities"]
+                if f.get("risk") == "critical"
+            ),
+        },
+        "results": results,
+    }
+
+    out_json = json.dumps(output, indent=2)
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(out_json)
+        print(f"Output written to {args.output}", file=sys.stderr)
+    else:
+        print(out_json)
+
+    print(
+        f"\nSummary: {total_post_approval} post-approval commits, "
+        f"{total_bot_only} bot-only approvals, {total_vulns} vulnerabilities",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Validate installed versions against OSV affected ranges before flagging (eliminates false positives like setuptools 83.0.0 flagged for CVEs fixed in v70-78)
- Dedup vulnerability findings within a repo by (package, version, vuln_id) so parsing both pyproject.toml and uv.lock doesn't double-count
- Group vulnerability findings across repos by (package, vuln_id) into one entry with a `repos: [...]` list instead of N identical rows
- Map severity to 4 levels (critical/high/medium/low) instead of binary critical-or-medium, with CVSS score parsing fallback

Tested on Aug 10-16 audit cache: 83 vulnerability findings collapsed to 50 unique with cross-repo dedup. Affected-range filtering will cut further on next live scan.

## Test plan

- [x] Both scripts parse cleanly (`ast.parse`)
- [x] `convert_audit.py` tested against live cache: 83 -> 50 vulns
- [x] `packaging` module available in runtime
- [x] Raw `findings` still emitted for backward compat, `findings_grouped` added alongside
- [ ] CI passes