### PR TITLE
fix: raise cryptography platform constraint to allow 50.x

### DIFF
--- a/src/team_devtools/check_platform_constraints.py
+++ b/src/team_devtools/check_platform_constraints.py
@@ -24,7 +24,7 @@ from packaging.version import Version
 PLATFORM_CONSTRAINTS = {
     "ansible-core": "<2.17",  # AAP 2.5/2.6 ships ansible-core 2.16.x
     "cffi": "<1.16",  # RHEL 8/9 ships cffi 1.15.x
-    "cryptography": "<38",  # downstream at 37
+    "cryptography": "<51",  # allow 50.x for Guardian CVE fixes
     "django": "<6.0",  # at 5.2
     "importlib-metadata": "<6.1",  # at 6.0.1
     "jsonschema": "<4.22",  # at 4.21.1


### PR DESCRIPTION
## Summary

Guardian prod CVE fixes require `cryptography>=50.0.0` in devtools repos. The current `cryptography<38` platform constraint blocks those bumps in CI (`check-platform-constraints`).

Raise the ceiling to `<51` so 50.x is allowed.

Needed by ansible-lint #5174 and pytest-ansible #618.

## Test plan

- [x] `uv run pytest test/test_check_platform_constraints.py`
- [x] `prek run --all-files` locally