### PR TITLE
fix(audit): merge ruleset required checks when legacy list is empty

### DIFF
--- a/.agents/skills/td-supply-chain-audit/scripts/collect.py
+++ b/.agents/skills/td-supply-chain-audit/scripts/collect.py
@@ -1338,7 +1338,16 @@ def collect_branch_protection(repo: str) -> dict:
     endpoint = f"repos/{repo}/branches/main/protection"
     data = gh_api(endpoint)
     if data and isinstance(data, dict) and "message" not in data:
-        return _legacy_branch_protection_result(data)
+        result = _legacy_branch_protection_result(data)
+        # Legacy API often returns empty required_status_checks.checks when the
+        # repo moved checks to rulesets (e.g. ansible/actions). Merge rulesets
+        # so audits do not false-positive "no required status checks".
+        if not result["required_checks"]:
+            ruleset_checks = _collect_ruleset_required_checks(repo)
+            if ruleset_checks:
+                result["required_checks"] = ruleset_checks
+                result["source"] = "branch_protection+rulesets"
+        return result
 
     required_checks = _collect_ruleset_required_checks(repo)
     if not required_checks:


### PR DESCRIPTION
## Summary

Weekly supply-chain audit flagged `ansible/actions` as having no required status checks even though the repo uses GitHub rulesets (`ack / ack`, `tox / check`, `check`, SonarCloud).

Legacy branch protection API still returns a protection object, but `required_status_checks.checks` is empty after checks moved to rulesets. `collect_branch_protection()` returned early without reading rulesets.

This merges ruleset required checks when the legacy list is empty.

## Test plan

- [ ] Run audit collector against `ansible/actions` and confirm required checks are populated
- [ ] Confirm repos with only legacy protection still behave as before